### PR TITLE
Fix typo Renoving to Removing.

### DIFF
--- a/Apps/Company Portal/installCompanyPortal.sh
+++ b/Apps/Company Portal/installCompanyPortal.sh
@@ -520,7 +520,7 @@ function installZIP () {
 
     if [[ -a "/Applications/$app" ]]; then
     
-      echo "$(date) | Renoving old installation at /Applications/$app"
+      echo "$(date) | Removing old installation at /Applications/$app"
       rm -rf "/Applications/$app"
     
     fi

--- a/Apps/Defender/installDefender.sh
+++ b/Apps/Defender/installDefender.sh
@@ -578,7 +578,7 @@ function installZIP () {
 
     if [[ -a "/Applications/$app" ]]; then
     
-      echo "$(date) | Renoving old installation at /Applications/$app"
+      echo "$(date) | Removing old installation at /Applications/$app"
       rm -rf "/Applications/$app"
     
     fi

--- a/Apps/Edge/installEdge.sh
+++ b/Apps/Edge/installEdge.sh
@@ -519,7 +519,7 @@ function installZIP () {
 
     if [[ -a "/Applications/$app" ]]; then
     
-      echo "$(date) | Renoving old installation at /Applications/$app"
+      echo "$(date) | Removing old installation at /Applications/$app"
       rm -rf "/Applications/$app"
     
     fi

--- a/Apps/Gimp/InstallGimp.sh
+++ b/Apps/Gimp/InstallGimp.sh
@@ -519,7 +519,7 @@ function installZIP () {
 
     if [[ -a "/Applications/$app" ]]; then
     
-      echo "$(date) | Renoving old installation at /Applications/$app"
+      echo "$(date) | Removing old installation at /Applications/$app"
       rm -rf "/Applications/$app"
     
     fi

--- a/Apps/Minecraft Education Edition/installMinecraftEE.sh
+++ b/Apps/Minecraft Education Edition/installMinecraftEE.sh
@@ -519,7 +519,7 @@ function installZIP () {
 
     if [[ -a "/Applications/$app" ]]; then
     
-      echo "$(date) | Renoving old installation at /Applications/$app"
+      echo "$(date) | Removing old installation at /Applications/$app"
       rm -rf "/Applications/$app"
     
     fi

--- a/Apps/Remote Desktop/installRemoteDesktop.sh
+++ b/Apps/Remote Desktop/installRemoteDesktop.sh
@@ -519,7 +519,7 @@ function installZIP () {
 
     if [[ -a "/Applications/$app" ]]; then
     
-      echo "$(date) | Renoving old installation at /Applications/$app"
+      echo "$(date) | Removing old installation at /Applications/$app"
       rm -rf "/Applications/$app"
     
     fi

--- a/Apps/Teams/installTeams.sh
+++ b/Apps/Teams/installTeams.sh
@@ -519,7 +519,7 @@ function installZIP () {
 
     if [[ -a "/Applications/$app" ]]; then
     
-      echo "$(date) | Renoving old installation at /Applications/$app"
+      echo "$(date) | Removing old installation at /Applications/$app"
       rm -rf "/Applications/$app"
     
     fi


### PR DESCRIPTION
Fixed typo 
echo "$(date) | Removing old installation at /Applications/$app"  
to
echo "$(date) | Removing old installation at /Applications/$app"  

