### PR TITLE
Update installMDATPQuickScanJob.sh

### DIFF
--- a/Misc/MDATP/installMDATPQuickScanJob.sh
+++ b/Misc/MDATP/installMDATPQuickScanJob.sh
@@ -45,7 +45,7 @@ cat > $plistfile <<EOF
 	<array>
 		<string>sh</string>
 		<string>-c</string>
-		<string>/usr/local/bin/mdatp --scan --quick</string>
+		<string>/usr/local/bin/mdatp scan quick</string>
 	</array>
 	<key>RootDirectory</key>
 	<string>/usr/local/bin</string>


### PR DESCRIPTION
`/usr/local/bin/mdatp --scan --quick` will not really run the scan but instead returns available commands.

```
% mdatp --scan --quick
Expected one of:
  config              	Manage product configuration
  connectivity        	Troubleshoot cloud connectivity
  definitions         	Manage security intelligence updates
  diagnostic          	Troubleshoot product issues and collect diagnostics
  edr                 	Manage Endpoint Detection & Response (EDR) configuration
  exclusion           	Manage antivirus exclusions
  health              	Display product health information
  help                	Display all available options for this tool
  log                 	Manage product logging
  notice              	Display the Third-Party Notice
  scan                	Scan for malicious software
  device-control      	Manage device control
  network-protection  	Manage network protection
  system-extension    	Manage system extensions
  threat              	Manage threats and configure threat handling policies
  version             	Display the product version
```