### PR TITLE
Exit if Company Portal Already Set up

### DIFF
--- a/Misc/Octory/installOctory.sh
+++ b/Misc/Octory/installOctory.sh
@@ -132,6 +132,15 @@ echo "# $(date) | Starting install of $appname"
 echo "############################################################"
 echo ""
 
+
+# Exit if machine has already been deployed and Company Portal plist detected
+if [[ -f "/Users/$consoleuser/Library/Preferences/com.microsoft.CompanyPortalMac.plist" ]]; then
+
+    echo "$(date) | Skipping Octory launch for user [$consoleuser], Company Portal already Launched."
+    exit 0
+
+fi
+
 # Check if we need Rosetta 2
 checkForRosetta2
 


### PR DESCRIPTION
Just a humble suggestion, deploying this in an existing environment may be problematic as is. This will prevent Octory from popping up on deployed systems. May be a better way but this is a simple solution.