### PR TITLE
Notifications settings for Microsoft Update Assistant

### DIFF
--- a/Custom Profiles/Notifications/Notifications for Intune, Defender and Office.mobileconfig
+++ b/Custom Profiles/Notifications/Notifications for Intune, Defender and Office.mobileconfig
@@ -155,6 +155,24 @@
 					<key>BadgesEnabled</key>
 					<true/>
 					<key>BundleIdentifier</key>
+					<string>com.microsoft.autoupdate.fba</string>
+					<key>CriticalAlertEnabled</key>
+					<true/>
+					<key>NotificationsEnabled</key>
+					<true/>
+					<key>ShowInCarPlay</key>
+					<true/>
+					<key>ShowInLockScreen</key>
+					<true/>
+					<key>ShowInNotificationCenter</key>
+					<true/>
+					<key>SoundsEnabled</key>
+					<true/>
+				</dict>				
+				<dict>
+					<key>BadgesEnabled</key>
+					<true/>
+					<key>BundleIdentifier</key>
 					<string>com.microsoft.edgemac</string>
 					<key>CriticalAlertEnabled</key>
 					<true/>


### PR DESCRIPTION
Added another dictionary for Microsoft Update Assistant (com.microsoft.autoupdate.fba), noticed this popping up on macOS Monterey. Maybe Microsoft Autoupdate (com.microsoft.autoupdate2) is going away?