### PR TITLE
Change URL to Zoom Admin Install

### DIFF
--- a/Apps/Zoom/installZoom.sh
+++ b/Apps/Zoom/installZoom.sh
@@ -18,7 +18,7 @@
 ## Feedback: neiljohn@microsoft.com
 
 # User Defined variables
-weburl="https://zoom.us/client/latest/Zoom.pkg"                             # What is the Azure Blob Storage URL?
+weburl="https://zoom.us/client/latest/ZoomInstallerIT.pkg"                  # What is the Azure Blob Storage URL?
 appname="Zoom"                                                              # The name of our App deployment script (also used for Octory monitor)
 app="zoom.us.app"                                                           # The actual name of our App once installed
 logandmetadir="/Library/Logs/Microsoft/IntuneScripts/installZoom"           # The location of our logs and last updated data


### PR DESCRIPTION
Consider use Admin install URL. This way its possible to use plist with intune.

https://zoom.us/client/latest/ZoomInstallerIT.pkg
Ref.:
https://support.zoom.us/hc/en-us/articles/115001799006-Mass-deploying-with-preconfigured-settings-for-macOS

"Once the .plist file is complete, it will need to be named us.zoom.config.plist. When deploying, as long as this file is in the same folder as the ZoomInstallerIT.pkg, the installation will automatically put the .plist file into the /Library/Preferences folder."