### PR TITLE
Added safety & efficiency when checking latest version

### DIFF
--- a/Apps/Defender/installDefender.sh
+++ b/Apps/Defender/installDefender.sh
@@ -236,8 +236,18 @@ fetchLastModifiedDate() {
         mkdir -p "$logandmetadir"
     fi
 
-    # generate the last modified date of the file we need to download
-    lastmodified=$(curl -sIL "$weburl" | grep -i "last-modified" | awk '{$1=""; print $0}' | awk '{ sub(/^[ \t]+/, ""); print }' | tr -d '\r')
+    # If lastmodified isn't already generated
+    if [[ -z $lastmodified ]]; then
+        # generate the last modified date of the file we need to download
+        lastmodified=$(curl -sIL "$weburl" --retry 5 --retry-delay 60 | grep -i "last-modified" | awk '{$1=""; print $0}' | awk '{ sub(/^[ \t]+/, ""); print }' | tr -d '\r')
+    fi
+
+    # Check if it was it successfully got the last modified date
+    if [[ -z $lastmodified ]]; then
+        echo "$(date) | Failed to get lastmodified from [$weburl]"
+        updateOctory failed
+        exit 1
+    fi
 
     if [[ $1 == "update" ]]; then
         echo "$(date) | Writing last modifieddate [$lastmodified] to [$metafile]"


### PR DESCRIPTION
Previously if the `curl` failed, `$lastmodified` is set to a blank string. Later on, it'll unnecessarily try to install an update because the versions mismatch. See screenshot for an example log of this happening.

![image](https://user-images.githubusercontent.com/205256/183341615-f2c13839-4502-4721-a79b-ec8eaaacc0f8.png)

Additionally, now `$lastmodified` is cached so when `fetchLastModifiedDate update` is called, it'll always be the same version and not have a risk of failure. 