### PR TITLE
DeviceRename.sh: Add OwnerPrefix & BYOD detection

### DIFF
--- a/macOS/Config/DeviceRename/DeviceRename.sh
+++ b/macOS/Config/DeviceRename/DeviceRename.sh
@@ -20,7 +20,7 @@
 
 ## Define variables
 appname="DeviceRename"
-logandmetadir="/Library/Logs/Microsoft/Intune/Scripts/$appname"
+logandmetadir="/Library/Logs/Microsoft/IntuneScripts/$appname"
 log="$logandmetadir/$appname.log"
 CorporatePrefix="CO"
 PersonalPrefix="BYO"

--- a/macOS/Config/DeviceRename/DeviceRename.sh
+++ b/macOS/Config/DeviceRename/DeviceRename.sh
@@ -91,7 +91,7 @@ if [ "$?" = "0" ]; then
   OwnerPrefix=$CorporatePrefix
 elif [ "$ABMOnly" = "false" ]; then
   if [[ "$firstrun" = "true" || "$EnforceBYOD" = "true" ]]; then
-    echo " $(date) | This device is enrolled manually, assuming BYOD scenario for one-time change."
+    echo " $(date) | This device is enrolled manually, assuming BYOD scenario."
     OwnerPrefix=$PersonalPrefix
   else
     echo " $(date) | This device was enrolled manually. Device name will not be enforced after initial change."

--- a/macOS/Config/DeviceRename/DeviceRename.sh
+++ b/macOS/Config/DeviceRename/DeviceRename.sh
@@ -113,6 +113,7 @@ case $ModelName in
   Mac\ Pro*) ModelCode=PRO;;
   Mac\ mini*) ModelCode=MINI;;
   Mac\ Studio*) ModelCode=MS;;
+  Apple\ Virtual\ Machine*) ModelCode=VM;;
   *) ModelCode=$(echo $ModelName | tr -d ' ' | cut -c1-4);;
 esac
 

--- a/macOS/Config/DeviceRename/DeviceRename.sh
+++ b/macOS/Config/DeviceRename/DeviceRename.sh
@@ -79,12 +79,6 @@ else
 fi
 
 
-## What is our public IP
-echo " $(date) | Looking up public IP"
-myip=$(dig +short myip.opendns.com @resolver1.opendns.com)
-Country=$(curl -s https://ipapi.co/$myip/country)
-
-
 profiles status -type enrollment | grep "Enrolled via DEP: Yes"
 if [ "$?" = "0" ]; then
   echo " $(date) | This device is enrolled by ABM"
@@ -101,6 +95,12 @@ else
   echo " $(date) | This device is not enrolled by ABM, device name will not be changed."
   exit 0
 fi
+
+
+## What is our public IP
+echo " $(date) | Looking up public IP"
+myip=$(dig +short myip.opendns.com @resolver1.opendns.com)
+Country=$(curl -s https://ipapi.co/$myip/country)
 
 
 echo " $(date) | Generating four characters code based on retrieved model name $ModelName"

--- a/macOS/Config/DeviceRename/readme.md
+++ b/macOS/Config/DeviceRename/readme.md
@@ -5,19 +5,27 @@ This is ideal for devices that are enrolled without user affinity. The script ca
 
 ## DeviceRename.sh
 
-The script consists of three steps:
+The script consists of five steps:
 1) determine the model type and, based on the retrieved type, set a 4 characters variable $ModelCode
     e.g. MacBook Air ==> $ModelCode = MABA
 2) collect the serial number and keep the first 10 characters
     e.g. Serial Number = C02BA222DC79 ==> $SerialNum = C02BA222DC
-3) build the final name by combining $ModelCode and $serial
-    e.g. $NewName = MABAC02BA222DC
+3) check MDM enrollment type and set $OwnerPrefix variable
+    e.g. enrolled via Apple Business Manager ==> $OwnerPrefix = CO, otherwise ==> $OwnerPrefix = BYO
+4) fetch country code, based on current IP address, set variable $Country
+    e.g. 209.142.68.29 ==> $Country = US
+5) build the final name by combining $ModelCode and $serial
+    e.g. ABM device ==> $NewName = CO-MBA-C02BA222DC-US, BYOD ==> BYO-MBA-C02BA222DC-US
 
-```
+```bash
 # Define variables
 appname="DeviceRename"
 logandmetadir="/Library/Logs/Microsoft/Intune/Scripts/$appname"
 log="$logandmetadir/$appname.log"
+CorporatePrefix="CO"   # May be adjusted, e.g. your company shortname, or set to empty string
+PersonalPrefix="BYO"   # May be adjusted, or set to empty string
+ABMOnly="false"        # Change to "true" to change device names for ABM enrolled devices only
+EnforceBYOD="false"    # Change to "true" if you want to run the script repeatedly and enforce device names for BYOD devices
 ```
 
 ## Script Settings
@@ -41,13 +49,14 @@ log="$logandmetadir/$appname.log"
  Mon Jan 25 16:18:29 GMT 2021 | Current computername detected as TestVM
  Mon Jan 25 16:18:29 GMT 2021 | Old Name: TestVM
  Mon Jan 25 16:18:30 GMT 2021 | Retrieved model name: MacBook Pro
+ Mon Jan 25 16:18:30 GMT 2021 | This device is enrolled by ABM
  Mon Jan 25 16:18:30 GMT 2021 | Generating four characters code based on retrieved model name MacBook Pro
- Mon Jan 25 16:18:30 GMT 2021 | ModelCode variable set to MABP
+ Mon Jan 25 16:18:30 GMT 2021 | ModelCode variable set to MBP
  Mon Jan 25 16:18:30 GMT 2021 | Retrieved serial number: ABCDEF000017
  Mon Jan 25 16:18:30 GMT 2021 | Building the new name...
- Mon Jan 25 16:18:30 GMT 2021 | Generated Name: MABPABCDEF000017
- Mon Jan 25 16:18:30 GMT 2021 | Computername changed from TestVM to MABPABCDEF000017
- Mon Jan 25 16:18:30 GMT 2021 | HostName changed from TestVM to MABPABCDEF000017
- Mon Jan 25 16:18:30 GMT 2021 | LocalHostName changed from TestVM to MABPABCDEF000017
+ Mon Jan 25 16:18:30 GMT 2021 | Generated Name: CO-MBP-ABCDEF000017-US
+ Mon Jan 25 16:18:30 GMT 2021 | Computername changed from TestVM to CO-MBP-ABCDEF000017-US
+ Mon Jan 25 16:18:30 GMT 2021 | HostName changed from TestVM to CO-MBP-ABCDEF000017-US
+ Mon Jan 25 16:18:30 GMT 2021 | LocalHostName changed from TestVM to CO-MBP-ABCDEF000017-US
 
 ```

--- a/macOS/Config/DeviceRename/readme.md
+++ b/macOS/Config/DeviceRename/readme.md
@@ -20,7 +20,7 @@ The script consists of five steps:
 ```bash
 # Define variables
 appname="DeviceRename"
-logandmetadir="/Library/Logs/Microsoft/Intune/Scripts/$appname"
+logandmetadir="/Library/Logs/Microsoft/IntuneScripts/$appname"
 log="$logandmetadir/$appname.log"
 CorporatePrefix="CO"   # May be adjusted, e.g. your company shortname, or set to empty string
 PersonalPrefix="BYO"   # May be adjusted, or set to empty string
@@ -37,7 +37,7 @@ EnforceBYOD="false"    # Change to "true" if you want to run the script repeated
 
 ### Log file example
 
->**Note:** The log file will output to **/Library/Logs/Microsoft/Intune/Scripts/DeviceRename/DeviceRename.log** by default. Exit status is either 0 or 1. To gather this log with Intune remotely take a look at  [Troubleshoot macOS shell script policies using log collection](https://docs.microsoft.com/en-us/mem/intune/apps/macos-shell-scripts#troubleshoot-macos-shell-script-policies-using-log-collection)
+>**Note:** The log file will output to **/Library/Logs/Microsoft/IntuneScripts/DeviceRename/DeviceRename.log** by default. Exit status is either 0 or 1. To gather this log with Intune remotely take a look at  [Troubleshoot macOS shell script policies using log collection](https://docs.microsoft.com/en-us/mem/intune/apps/macos-shell-scripts#troubleshoot-macos-shell-script-policies-using-log-collection)
 
 ```
 ##############################################################


### PR DESCRIPTION
This patch adds an owner prefix to the name that is based on the device enrollment type.

The configuration is flexible:

- `$CorporatePrefix` may be empty so that no prefix will be added to the name.
- `$PersonalPrefix` may be empty so that no prefix will be added to the name.
- `$ABMOnly` may be set to `true` so that only corporate devices that were enrolled by ABM will have their device name changed. For other devices, the name will only be changed once so the user may change it back.
- `$EnforceBYOD` will enforce the device name also on devices that were not enrolled by ABM.