### PR TITLE
log directory Intune/Scripts > IntuneScripts

### DIFF
--- a/macOS/Config/DeviceRename/DeviceRename.sh
+++ b/macOS/Config/DeviceRename/DeviceRename.sh
@@ -20,7 +20,7 @@
 
 ## Define variables
 appname="DeviceRename"
-logandmetadir="/Library/Logs/Microsoft/Intune/Scripts/$appname"
+logandmetadir="/Library/Logs/Microsoft/IntuneScripts/$appname"
 log="$logandmetadir/$appname.log"
 
 ## Check if the log directory has been created

--- a/macOS/Config/DeviceRename/readme.md
+++ b/macOS/Config/DeviceRename/readme.md
@@ -16,7 +16,7 @@ The script consists of three steps:
 ```
 # Define variables
 appname="DeviceRename"
-logandmetadir="/Library/Logs/Microsoft/Intune/Scripts/$appname"
+logandmetadir="/Library/Logs/Microsoft/IntuneScripts/$appname"
 log="$logandmetadir/$appname.log"
 ```
 
@@ -29,7 +29,7 @@ log="$logandmetadir/$appname.log"
 
 ### Log file example
 
->**Note:** The log file will output to **/Library/Logs/Microsoft/Intune/Scripts/DeviceRename/DeviceRename.log** by default. Exit status is either 0 or 1. To gather this log with Intune remotely take a look at  [Troubleshoot macOS shell script policies using log collection](https://docs.microsoft.com/en-us/mem/intune/apps/macos-shell-scripts#troubleshoot-macos-shell-script-policies-using-log-collection)
+>**Note:** The log file will output to **/Library/Logs/Microsoft/IntuneScripts/DeviceRename/DeviceRename.log** by default. Exit status is either 0 or 1. To gather this log with Intune remotely take a look at  [Troubleshoot macOS shell script policies using log collection](https://docs.microsoft.com/en-us/mem/intune/apps/macos-shell-scripts#troubleshoot-macos-shell-script-policies-using-log-collection)
 
 ```
 ##############################################################

--- a/macOS/Config/Manage Accounts/createLocalAdminAccount.sh
+++ b/macOS/Config/Manage Accounts/createLocalAdminAccount.sh
@@ -31,7 +31,7 @@
 adminaccountname="localadmin"       # This is the accountname of the new admin
 adminaccountfullname="Local Admin"  # This is the full name of the new admin user
 scriptname="Create Local Admin Account"
-logandmetadir="/Library/Intune/Scripts/createLocalAdminAccount"
+logandmetadir="/Library/IntuneScripts/createLocalAdminAccount"
 log="$logandmetadir/createLocalAdminAccount.log"
 
 # function to delay until the user has finished setup assistant.

--- a/macOS/Config/Manage Accounts/downgradeUsertoStandard.sh
+++ b/macOS/Config/Manage Accounts/downgradeUsertoStandard.sh
@@ -30,7 +30,7 @@ scriptname="Downgrade Admin Users to Standard"
 log="/var/log/downgradeadminusers.log"
 abmcheck=true   # Only downgrade users if this device is ABM managed
 downgrade=true  # If set to false, script will not do anything
-logandmetadir="/Library/Intune/Scripts/downgradeAdminUsers"
+logandmetadir="/Library/IntuneScripts/downgradeAdminUsers"
 log="$logandmetadir/downgradeAdminUsers.log"
 
 ## Check if the log directory has been created and start logging

--- a/macOS/Config/Manage Accounts/removeLocalAdminAccount.sh
+++ b/macOS/Config/Manage Accounts/removeLocalAdminAccount.sh
@@ -27,7 +27,7 @@
 adminaccountname="localadmin"       # This is the accountname of the new admin
 adminaccountfullname="Local Admin"  # This is the full name of the new admin user
 scriptname="Remove Local Admin Account"
-logandmetadir="/Library/Intune/Scripts/removeLocalAdminUser"
+logandmetadir="/Library/IntuneScripts/removeLocalAdminUser"
 log="$logandmetadir/removeLocalAdminUser.log"
 
 ## Check if the log directory has been created and start logging


### PR DESCRIPTION
A few configuration scripts use a different log directory. I think this is by mistake and should be corrected to match all the other scripts.