### PR TITLE
Update runMDATPQuickScan.sh

### DIFF
--- a/macOS/Config/MDATP/runMDATPQuickScan.sh
+++ b/macOS/Config/MDATP/runMDATPQuickScan.sh
@@ -29,3 +29,5 @@ echo "############################################################"
 echo ""
 
 /usr/local/bin/mdatp scan quick >/dev/null
+
+exit 0


### PR DESCRIPTION
Fixes error when deploying via intune. Intune shows it executed with an error even though it ran successfully.  Added exit 0 at the end of the script fixes it.