### PR TITLE
Update com.microsoft.autoupdate2_current.plist

### DIFF
--- a/macOS/Apps/Office for Mac/MAU Plist/com.microsoft.autoupdate2_current.plist
+++ b/macOS/Apps/Office for Mac/MAU Plist/com.microsoft.autoupdate2_current.plist
@@ -1,5 +1,5 @@
 <key>AcknowledgedDataCollectionPolicy</key>
-<string>RequiredAndOptionalData</string>
+<string>RequiredDataOnly</string>
 <key>ChannelName</key>
 <string>Current</string>
 <key>UpdateCache</key>


### PR DESCRIPTION
RequiredAndOptionalData seems to no longer be honored by Office for Mac. Info about it is here https://www.kevinmcox.com/2024/04/changes-to-microsoft-autoupdates-required-data-notice/