### PR TITLE
Update installApp3.01-GoogleChrome.sh

### DIFF
--- a/macOS/Apps/Google Chrome/installApp3.01-GoogleChrome.sh
+++ b/macOS/Apps/Google Chrome/installApp3.01-GoogleChrome.sh
@@ -24,7 +24,7 @@
 ## Feedback: neiljohn@microsoft.com
 
 # User Defined variables
-weburl="https://dl.google.com/chrome/mac/stable//googlechrome.dmg"              # What is the Azure Blob Storage URL?
+weburl="https://dl.google.com/dl/chrome/mac/universal/stable/gcea/googlechrome.dmg"              # What is the Azure Blob Storage URL?
 appname="Google Chrome"                                                        # The name of our App deployment script (also used for Octory monitor)
 app="Google Chrome.app"                                                        # The actual name of our App once installed
 logandmetadir="/Library/Logs/Microsoft/IntuneScripts/GoogleChrome"             # The location of our logs and last updated data


### PR DESCRIPTION
Updates the web URL to support the use of the universal binary for Google Chrome Enterprise on macOS in .DMG format. The universal binary supports both x86 and ARM (Apple M chips). The use of the enterprise edition (gcea) is relevant here since these Intune scripts will be primarily used in enterprise environments.

Installing the Google Chrome Enterprise app in an unattended mode will automatically accept the EULA, however it's been a good practice to build this into any installer automations to accept the EULA. 