### PR TITLE
Update Notifications for Intune, Defender and Office.mobileconfig

### DIFF
--- a/macOS/Custom Profiles/Notifications/Notifications for Intune, Defender and Office.mobileconfig
+++ b/macOS/Custom Profiles/Notifications/Notifications for Intune, Defender and Office.mobileconfig
@@ -281,7 +281,7 @@
 					<key>BadgesEnabled</key>
 					<true/>
 					<key>BundleIdentifier</key>
-					<string>com.microsoft.OneDrive</string>
+					<string>com.microsoft.OneDrive-mac</string>
 					<key>CriticalAlertEnabled</key>
 					<false/>
 					<key>NotificationsEnabled</key>
@@ -336,6 +336,24 @@
 					<true/>
 					<key>BundleIdentifier</key>
 					<string>com.microsoft.wdav.tray</string>
+					<key>CriticalAlertEnabled</key>
+					<true/>
+					<key>NotificationsEnabled</key>
+					<true/>
+					<key>ShowInCarPlay</key>
+					<true/>
+					<key>ShowInLockScreen</key>
+					<true/>
+					<key>ShowInNotificationCenter</key>
+					<true/>
+					<key>SoundsEnabled</key>
+					<true/>
+				</dict>
+				<dict>
+					<key>BadgesEnabled</key>
+					<true/>
+					<key>BundleIdentifier</key>
+					<string>com.microsoft.teams2</string>
 					<key>CriticalAlertEnabled</key>
 					<true/>
 					<key>NotificationsEnabled</key>


### PR DESCRIPTION
Adjust duplicate OneDrive entry to OneDrive for macOS from App Store (different bundle identifier as per https://learn.microsoft.com/en-us/sharepoint/deploy-and-configure-on-macos#manage-onedrive-settings-on-macos-using-property-list-plist-files)

Add new Microsoft Teams (com.microsoft.teams2)