### PR TITLE
Intune to Intune migration, Office reset and deferral support

### DIFF
--- a/macOS/Tools/Migration/IntuneToIntuneMigrationSample.sh
+++ b/macOS/Tools/Migration/IntuneToIntuneMigrationSample.sh
@@ -1,0 +1,661 @@
+#!/bin/bash
+
+#########################################################################################################
+#                                                                                                       #
+#                                  Microsoft Script Disclaimer                                          #
+#                                                                                                       #
+# This script is provided "AS IS" without warranty of any kind. Microsoft disclaims all implied         #
+# warranties, including, without limitation, any implied warranties of merchantability or fitness       #
+# for a particular purpose. The entire risk arising out of the use or performance of this script        #
+# and associated documentation remains with you. In no event shall Microsoft, its authors, or any       #
+# contributors be liable for any damages whatsoever (including, but not limited to, damages for         #
+# loss of business profits, business interruption, loss of business information, or other pecuniary     #
+# loss) arising out of the use of or inability to use this script or documentation, even if             #
+# Microsoft has been advised of the possibility of such damages.                                        #
+#                                                                                                       #
+# Feedback: neiljohn@microsoft.com                                                                      #
+#                                                                                                       #
+#########################################################################################################
+
+# Script: IntuneToIntuneMigrationSample.sh
+# -------------------------------------------------------------------------------------------------------
+# Description:
+# This script removes the Intune from a Mac and prepares the device for migration to Microsoft 
+# Intune. It prompts the user to start the migration process, removes the Company Portal data, sidecar, installs the 
+# Microsoft Intune Company Portal app (if needed), checks if the device is ADE-enrolled, and renews 
+# profiles as necessary.
+# -------------------------------------------------------------------------------------------------------
+# Dependencies:
+# - ADE: Device must be assigned to Intune before beginning the migration process
+# - This script just handles the removal of Intune and either starting setup assistant or Company Portal
+#   for the user to complete migration. The onboarding process should be configured in Intune separately.
+# -------------------------------------------------------------------------------------------------------
+#########################################################################################################
+
+#region Configuration
+
+# Set the maximum deferral count for the migration prompt, set to 0 to disable deferrals
+# If the deferral count is reached, the Exit button will be disabled
+max_deferral_count=0
+deferral_count_file="/Library/Preferences/com.microsoft.intune_migration.deferral_count.plist"
+# Set if Swift Dialog should be uninstalled after migration
+uninstall_swiftdialog=false
+# Reset office for the user, uses OfficeReset.com
+reset_office=false
+
+# Set to false if you do not want to blur the screen during dialog display
+blur_screen=true
+blur_screen_string="--blurscreen"
+# Set the font options for the dialog title
+title_font_options="shadow=0,name=SFProDisplay-Regular"
+# Banner colour
+banner_colour="blue"
+
+# Messages for the migration prompt and progress dialog
+migration_message_intune="Your device is scheduled to be migrated from **current Microsoft Intune tenant** to another **Microsoft Intune tenant**"
+progress_message_intune="Your device is being migrated from one Microsoft Intune tenant to another"
+
+# Graph API details
+# Set the GRAPH_ENDPOINT to the appropriate Intune API endpoint
+GRAPH_ENDPOINT="https://graph.microsoft.com/v1.0/deviceManagement/managedDevices"
+# Set the client ID, client secret, and tenant ID for the Graph API
+CLIENT_ID=""
+CLIENT_SECRET=""
+TENANT_ID=""
+
+#endregion
+
+# Create deferred count file if it doesn't exist
+if [ ! -f "$deferral_count_file" ]; then
+  echo "Creating deferral count file..."
+  sudo defaults write "$deferral_count_file" deferral_count -int 0
+fi
+
+if [ $blur_screen = false ]; then
+  blur_screen_string=""
+fi
+
+#region Dialogs
+
+# Function to display message to sign in to Company Portal
+cp_sign_in_message() {
+  /usr/local/bin/dialog \
+    --bannertitle "Action Required: Sign in to Company Portal" \
+    --message "To complete your device setup, you must sign in to the Company Portal app using your **Entra (Microsoft)** credentials.\n\nFailure to sign in to Company Portal will result in the loss of access to corporate resources such as **e-Mail** and **other essential services**.\n\nWhen you close this dialog, Company Portal will be open your screen, click **Sign-in** and complete the process to avoid service disruptions." \
+    --button1text "Got it" \
+    $blur_screen_string \
+    --bannerimage colour=$banner_colour \
+    --titlefont "$title_font_options" \
+    --width 750 \
+    --height 450 \
+    --icon /Applications/Company\ Portal.app/Contents/Resources/AppIcon.icns
+}
+
+# Function to display "Waiting for Intune" message with spinner
+waiting_for_intune() {
+  /usr/local/bin/dialog \
+    --bannertitle "Status: Waiting for Intune" \
+    --message "Your device setup is in progress.\n\nWe're currently waiting for Intune to complete the necessary setup. This may take a few minutes.\n\nPlease keep this window open until setup is complete." \
+    $blur_screen_string \
+    --bannerimage colour=$banner_colour \
+    --titlefont "$title_font_options" \
+    --progress \
+    --width 750 \
+    --height 450 \
+    --icon /Applications/Company\ Portal.app/Contents/Resources/AppIcon.icns \
+    --no-buttons
+    --progress &
+  
+  # Capture the dialog process ID to close it later if needed
+  DIALOG_PID=$!
+}
+
+# Function to display message for ADE enrollment
+ade_enrollment_message() {
+  /usr/local/bin/dialog \
+    --bannertitle "Action Required: Complete Device Enrollment" \
+    --message "Your device is **ADE-enrolled** and requires additional setup to complete enrollment into **Intune**.\n\nPlease follow the setup assistant screens to sign in with your **Entra (Microsoft)** credentials. This process is necessary to gain access to corporate resources, including **e-Mail** and other essential services.\n\nWhen you close this dialog, the setup assistant will open. Follow the prompts to complete the enrollment process." \
+    --button1text "Got it" \
+    $blur_screen_string \
+    --bannerimage colour=$banner_colour \
+    --titlefont "$title_font_options" \
+    --width 750 \
+    --height 450 \
+    --icon /Applications/Company\ Portal.app/Contents/Resources/AppIcon.icns
+}
+
+# Function to prompt the user to start the migration
+prompt_migration() {
+
+    message=$migration_message_intune
+
+    if [ $max_deferral_count -gt 0 ]; then
+        button2text="Defer"
+        deferral_message="\n\nYou can defer this migration up to **$max_deferral_count** times. After that, the Defer button will be disabled. \n\nYou have **$((max_deferral_count - DEFERRAL_COUNT))** deferral(s) remaining."
+    else
+        deferral_message=""
+        button2text="Exit"
+    fi
+
+  # Display the dialog with improved message text
+  /usr/local/bin/dialog \
+    --bannertitle "Prepare for Device Migration" \
+    --message "${message}.\n\nThis process will take approximately **20 minutes**, during which you will **not be able to use your Mac**.${deferral_message}" \
+    --button1text "Migrate" \
+    $( [[ $((DEFERRAL_COUNT)) -lt $((max_deferral_count)) || $((max_deferral_count)) -eq 0 ]] && echo "--button2text $button2text" ) \
+    $blur_screen_string \
+    --bannerimage colour=$banner_colour \
+    --titlefont "$title_font_options" \
+    --width 750 \
+    --height 450 \
+    --icon /Applications/Company\ Portal.app/Contents/Resources/AppIcon.icns
+
+  # Check which button was clicked based on the exit code
+  if [[ "$?" -eq 0 ]]; then
+    echo "User chose to migrate the device."
+    USER_READY=true
+  else
+    USER_READY=false
+  fi
+}
+
+#endregion
+
+#region Helper Functions
+
+# Function to check if the device is managed by Intune
+check_if_managed() {
+    if profiles -P | grep -q "Microsoft.Profiles.MDM"; then
+        echo "Checking if the device is managed by Intune..."
+    else
+        echo "Device is not managed by Intune. Exiting script."
+        exit 0
+    fi
+}
+
+function startLog() {
+
+    ###################################################
+    ###################################################
+    ##
+    ##  Start logging - Output to log file and STDOUT
+    ##
+    ####################
+    ####################
+
+    LOG_DIR=$(dirname "$LOG")  # Extract the directory path from the LOG file path
+
+    if [[ ! -d "$LOG_DIR" ]]; then
+        ## Creating log directory
+        echo "$(date) | Creating directory [$LOG_DIR] to store logs"
+        mkdir -p "$LOG_DIR"
+    fi
+
+    exec > >(tee -a "$LOG") 2>&1
+}
+
+# Function to check and install swiftDialog if not present
+install_swiftDialog() {
+  if [ ! -f "/usr/local/bin/dialog" ]; then
+    echo "swiftDialog not found. Installing swiftDialog..."
+    curl -L -o /tmp/dialog.pkg "https://github.com/swiftDialog/swiftDialog/releases/download/v2.5.2/dialog-2.5.2-4777.pkg"
+    sudo installer -pkg /tmp/dialog.pkg -target /
+    rm /tmp/dialog.pkg
+    echo "swiftDialog installed successfully."
+  else
+    echo "swiftDialog is already installed."
+  fi
+}
+
+uninstall_swiftDialog() {
+  if [ "$uninstall_swiftdialog" = true ]; then
+    echo "Uninstalling swiftDialog..."
+    sudo rm -f /usr/local/bin/dialog
+    sudo rm -r "/Library/Application Support/Dialog/"
+    sudo pkgutil --forget au.csiro.dialogcli
+  fi
+}
+
+uninstall_sidecar() {
+  echo "Uninstalling Sidecar..."
+  sidecar_app_path="/Library/Intune"
+  sidecar_ld_name="com.microsoft.intuneMDMAgent.daemon"
+  sidecar_la_name="com.microsoft.intuneMDMAgent"
+  sidecar_db_path="/Library/Application Support/Microsoft/Intune/SideCar"
+  sidecar_launchagent_path="/Library/LaunchAgents/$sidecar_la_name.plist"
+  sidecar_launchdaemon_path="/Library/LaunchDaemons/$sidecar_ld_name.plist"
+  console_user=$(/usr/bin/stat -f "%Su" /dev/console)
+  console_user_uid=$(/usr/bin/id -u "$console_user")
+
+  if [ -d "$sidecar_app_path" ]; then
+    rm -rf "$sidecar_app_path"
+  fi
+
+  if [ -d "$sidecar_db_path" ]; then
+    rm -rf "$sidecar_db_path"
+  fi
+
+  if [ -f "$sidecar_launchagent_path" ]; then
+    /bin/launchctl asuser "${console_user_uid}" /bin/launchctl unload -w  "$sidecar_launchagent_path"
+    rm -f "$sidecar_launchagent_path"
+  fi
+
+  if [ -f "$sidecar_launchdaemon_path" ]; then
+    # is it loaded?
+    if launchctl print "system/${sidecar_ld_name}" &> /dev/null ; then
+      /bin/launchctl unload "$sidecar_launchdaemon_path"
+    fi
+    rm -f "$sidecar_launchdaemon_path"
+  fi
+
+  killall "IntuneMdmAgent"
+}
+
+# Function to check if jq is installed, and if not, install it
+check_and_install_jq() {
+  if ! command -v jq &> /dev/null; then
+    echo "jq not found. Installing jq..."
+
+    # If Homebrew is available, use it
+    if command -v brew &> /dev/null; then
+      echo "Homebrew detected. Installing jq with brew..."
+      brew install jq
+    else
+      # If brew is not installed, attempt a direct download
+      echo "Homebrew not detected. Downloading jq binary from GitHub..."
+      JQ_TEMP_DIR="/tmp/jq_install"
+      mkdir -p "$JQ_TEMP_DIR"
+      
+      # For Apple Silicon / Intel detection:
+      ARCH=$(uname -m)
+        if [[ $ARCH == "arm64" ]]; then
+        JQ_URL="https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-macos-arm64"
+        else
+        JQ_URL="https://github.com/stedolan/jq/releases/latest/download/jq-osx-amd64"
+        fi
+
+      curl -L "$JQ_URL" -o "$JQ_TEMP_DIR/jq"
+      
+      # Move the downloaded binary to /usr/local/bin (or /usr/local/bin could be replaced with /usr/bin/local on older systems)
+      chmod +x "$JQ_TEMP_DIR/jq"
+      sudo mv "$JQ_TEMP_DIR/jq" /usr/local/bin/jq
+      rm -rf "$JQ_TEMP_DIR"
+    fi
+
+    # Verify installation
+    if command -v jq &> /dev/null; then
+      echo "jq was successfully installed."
+    else
+      echo "Failed to install jq. Please install it manually."
+      exit 1
+    fi
+  else
+    echo "jq is already installed."
+  fi
+}
+
+# Function to update the dialog progress bar and text via the command file
+update_progress() {
+  local progress_value="$1"
+  local progress_text="$2"
+  
+  # Write the progress value and text separately to the command file
+  echo "progress: $progress_value" > "$COMMAND_FILE"
+  echo "progresstext: $progress_text" >> "$COMMAND_FILE"
+  
+  # Add a small delay to ensure swiftDialog processes each update properly
+  sleep 1
+}
+
+office_reset() {
+  if [ "$reset_office" = true ]; then
+    update_progress 30 "Resetting Office..."
+    echo "Resetting Office..."
+    curl -L -o /tmp/OfficeReset.pkg "https://office-reset.com/download/Microsoft_Office_Factory_Reset_1.9.1.pkg"
+    sudo installer -pkg /tmp/OfficeReset.pkg -target /
+    rm /tmp/OfficeReset.pkg
+  fi
+}
+
+# Function to start the migration dialog in progress mode
+start_progress_dialog() {
+  COMMAND_FILE="/tmp/dialog_command"
+  echo "Initializing migration..." > "$COMMAND_FILE"
+
+  message=$progress_message_intune
+  
+  /usr/local/bin/dialog \
+    --bannertitle "Device Migration in Progress" \
+    --icon /Applications/Company\ Portal.app/Contents/Resources/AppIcon.icns \
+    --bannerimage colour=$banner_colour \
+    --titlefont "$title_font_options" \
+    --message "${message}. Please do not power off or disconnect your device during this process." \
+    $blur_screen_string \
+    --force \
+    --no-buttons \
+    --progress \
+    --width 750 \
+    --height 450 \
+    --commandfile "$COMMAND_FILE" &
+  
+  DIALOG_PID=$!
+}
+
+# Function to clean Company Portal app if needed
+clean_company_portal() {
+  sudo killall "Company Portal"
+
+  currentuser=`stat -f "%Su" /dev/console`
+  rm -rf /Users/"$currentuser"/Library/Saved\ Application\ State/com.microsoft.CompanyPortalMac.savedState
+  rm -rf /Users/"$currentuser"/Library/Application\ Support/com.microsoft.CompanyPortalMac
+  rm -rf /Users/"$currentuser"/Library/Application\ Support/com.microsoft.CompanyPortalMac.usercontext.info
+  su "$currentuser" -c "security delete-generic-password -l 'com.microsoft.adalcache'"
+  su "$currentuser" -c "security delete-generic-password -l 'enterpriseregistration.windows.net'"
+  su "$currentuser" -c "security delete-generic-password -l 'https://device.login.microsoftonline.com'"
+  su "$currentuser" -c "security delete-generic-password -l 'https://device.login.microsoftonline.com/' "
+  su "$currentuser" -c "security delete-generic-password -l 'https://enterpriseregistration.windows.net' "
+  su "$currentuser" -c "security delete-generic-password -l 'https://enterpriseregistration.windows.net/' "
+}
+
+# Function to check and install the Intune Company Portal app if not present
+install_cp() {
+  if [ ! -d "/Applications/Company Portal.app" ]; then
+    echo "Company Portal not found. Installing Company Portal..."
+    curl -L -C - -o /tmp/cp.pkg "https://go.microsoft.com/fwlink?linkid=853070"
+    sudo installer -pkg /tmp/cp.pkg -target /
+    rm /tmp/cp.pkg
+    echo "Company Portal installed successfully."
+  else
+    echo "Company Portal is already installed."
+  fi
+}
+
+launch_company_portal() {
+  # Open the Company Portal app
+  open -a "/Applications/Company Portal.app"
+  
+  # Bring Company Portal to the front
+  osascript <<EOF
+    tell application "Company Portal" to activate
+EOF
+}
+
+# Function to get the serial number of the current Mac
+get_serial_number() {
+  system_profiler SPHardwareDataType | awk '/Serial Number/ {print $4}'
+}
+
+#endregion
+
+#region Intune API Functions
+
+get_graph_auth_token() {
+    local response
+
+    echo "DEBUG: Getting access token..." >&2
+
+    response=$(curl -s -X POST \
+        -d "client_id=$CLIENT_ID" \
+        -d "scope=https://graph.microsoft.com/.default" \
+        -d "client_secret=$CLIENT_SECRET" \
+        -d "grant_type=client_credentials" \
+        "https://login.microsoftonline.com/$TENANT_ID/oauth2/v2.0/token")
+        
+    if echo "$response" | jq -e '.error' >/dev/null; then
+        echo "Failed to get access token: $response" >&2
+        exit 1
+    else
+        echo "$response" | jq -r '.access_token'
+    fi
+}
+
+get_intune_device_id() {
+    local serial_number="$1"
+    local access_token="$2"  # Access token should be passed as an argument
+    local response
+
+    echo "DEBUG: Getting device ID..." >&2
+
+    # Ensure the access token is set
+    if [ -z "$access_token" ]; then
+        echo "Error: Access token is missing!" >&2
+        exit 1
+    fi
+
+    # Ensure GRAPH_ENDPOINT is set
+    if [ -z "$GRAPH_ENDPOINT" ]; then
+        echo "Error: GRAPH_ENDPOINT is not set!" >&2
+        exit 1
+    fi
+
+    # Correct Authorization header and properly format the filter query
+    response=$(curl -s -X GET \
+        -H "Authorization: Bearer $access_token" \
+        -H "Content-Type: application/json" \
+        "$GRAPH_ENDPOINT?\$filter=serialNumber%20eq%20'$serial_number'")
+
+    if echo "$response" | jq -e '.error' >/dev/null; then
+        echo "Failed to get device ID: $response" >&2
+        exit 1
+    else
+        # verify we only have one device
+        if [ $(echo "$response" | jq -r '.value | length') -ne 1 ]; then
+            echo "Error: Multiple devices found for serial number: $serial_number" >&2
+            exit 1
+        fi
+        echo "$response" | jq -r '.value[0].id'
+    fi
+}
+
+unmanage_device_from_intune() {
+    local device_id="$1"
+    local access_token="$2"
+    local response
+
+    echo "DEBUG: Unmanaging device..." >&2
+
+    update_progress 50 "Removing Intune management..."
+
+    # Ensure required parameters are provided
+    if [ -z "$device_id" ] || [ -z "$access_token" ]; then
+        echo "Error: Missing device ID or access token!" >&2
+        exit 1
+    fi
+
+    # Send the unmanage device command
+    response=$(curl -s -X DELETE \
+        -H "Authorization: Bearer $access_token" \
+        "$GRAPH_ENDPOINT/$device_id")
+
+    if echo "$response" | jq -e '.error' >/dev/null; then
+        echo "Failed to unmanage device: $response" >&2
+        exit 1
+    else
+        echo "Device successfully unmanaged."
+    fi
+}
+
+#endregion
+
+#region MDM Profile Removal
+
+# Function to check if the device is ADE enrolled
+check_ade_enrollment() {
+  echo "Checking if the device is ADE enrolled..."
+
+  # Run profiles status to check for DEP enrollment
+  ade_status=$(profiles status -type enrollment 2>/dev/null | grep -i "Enrolled via DEP: Yes")
+
+  if [ -n "$ade_status" ]; then
+    echo "Device is ADE enrolled."
+    ADE_ENROLLED=true
+  else
+    echo "Device is not ADE enrolled."
+    ADE_ENROLLED=false
+  fi
+}
+
+wait_for_management_profile_removal() {
+  echo "Waiting for MDM management profile removal..."
+  local timeout=1800
+  local interval=5
+  local elapsed=0
+
+  update_progress 70 "Waiting for MDM management profile removal..."
+
+  while true; do
+    # Capture the enrollment profiles output.
+    local output
+    output=$(profiles show type -enrollment 2>/dev/null)
+
+    # Check if there are no enrollment profiles or if the MDM payload is missing.
+    if echo "$output" | grep -q "There are no configuration profiles installed" || \
+       ! echo "$output" | grep -q "com.apple.mdm"; then
+      echo "MDM management profile successfully removed."
+      break
+    else
+      echo "MDM management profile still present. Retrying in ${interval} seconds..."
+    fi
+
+    sleep "${interval}"
+    elapsed=$((elapsed + interval))
+    if [ $elapsed -ge $timeout ]; then
+      echo "Timeout waiting for management profile removal." >&2
+      exit 1
+    fi
+  done
+}
+
+# Function to renew profiles if the device is ADE enrolled
+renew_profiles() {
+  sudo profiles renew -type enrollment
+  echo "Profiles renewed."
+}
+
+# Function to unmanage the device from Intune
+remove_intune_management() {
+  update_progress 50 "Removing Intune management..."
+  echo "Removing Intune management..."
+  sudo profiles -R -p "Microsoft.Profiles.MDM"
+  echo "Intune management removed."
+}
+
+#endregion
+
+############################################################
+##
+## Main Script Execution Begins Here
+##
+#########################################
+
+#region Main Script Execution
+
+# Start Logging before we do anything else...
+startLog
+
+# Flag to track ADE enrollment
+ADE_ENROLLED=false
+
+# Flag to track user readiness
+USER_READY=false
+
+# Check if the device is managed
+check_if_managed
+
+# Install swiftDialog if needed
+# Install dependencies if needed
+install_cp
+install_swiftDialog
+check_and_install_jq
+
+#Launch initial migration prompt
+DEFERRAL_COUNT=$(defaults read "$deferral_count_file" deferral_count)
+
+prompt_migration
+
+DEFERRAL_COUNT=$((DEFERRAL_COUNT + 1))
+
+# Exit script if user chose not to migrate
+if [ "$USER_READY" = false ]; then
+  echo "User chose to exit the migration process. Exiting script."
+    # Inrement deferral count
+    if [ $max_deferral_count -eq 0 ]; then
+      echo "Deferral count is disabled. Exiting script."
+      exit 0
+    fi
+
+    sudo defaults write "$deferral_count_file" deferral_count -int "$DEFERRAL_COUNT"
+    echo "Deferral count not reached: $DEFERRAL_COUNT"
+    exit 0
+fi
+
+#Launch actual migration dialog
+start_progress_dialog
+
+# Call the function to reset office
+office_reset
+
+# Check ADE enrollment before unmanaging the device
+check_ade_enrollment
+
+if [ $ADE_ENROLLED = true ]; then
+  if [ -z "$CLIENT_ID" ] || [ -z "$CLIENT_SECRET" ] || [ -z "$TENANT_ID" ]; then
+    echo "GRAPH API details are missing!" >&2
+    exit 1
+  else
+    serial_number=$(get_serial_number)
+    echo "Serial Number: $serial_number"
+    # Get the device ID from Intune
+    access_token=$(get_graph_auth_token)
+    device_id=$(get_intune_device_id "$serial_number" "$access_token")
+    echo "Device ID: $device_id"
+
+    # Unmanage the device from Intune
+    unmanage_device_from_intune "$device_id" "$access_token"
+
+    # Clean up the Company Portal app
+    clean_company_portal
+
+    # Wait for management profile to be removed
+    wait_for_management_profile_removal
+  fi
+else
+  remove_intune_management
+  clean_company_portal
+fi
+
+uninstall_sidecar
+update_progress 90 "Device removed from Intune, now starting Intune Migration"
+sleep 2
+
+# Close Dialog
+killall Dialog
+
+# If the device was ADE enrolled, renew profiles
+if [ "$ADE_ENROLLED" = true ]; then
+
+    # Show end user dialog about ADE enrollment process
+    ade_enrollment_message
+
+    # Renew profiles to trigger Intune setup
+    renew_profiles
+
+    # Show waiting for Intune dialog, this will remain open until Intune setup is complete and the onboarding script runs
+    sleep 5
+    waiting_for_intune
+else
+
+    # Show sign-in message for Company Portal
+    cp_sign_in_message
+
+    # Launch Company Portal
+    launch_company_portal
+fi
+
+# Uninstall swiftDialog
+uninstall_swiftDialog
+
+# Clean up the deferral count file
+sudo rm -f "$deferral_count_file"
+
+#endregion

--- a/macOS/Tools/Migration/intuneMigrationSample.sh
+++ b/macOS/Tools/Migration/intuneMigrationSample.sh
@@ -27,177 +27,25 @@
 # -------------------------------------------------------------------------------------------------------
 # Dependencies:
 # - ADE: Device must be assigned to Intune before beginning the migration process
-# - This script just handles the removal of Jamf/Intune and either starting setup assistant or Company Portal
+# - This script just handles the removal of Jamf and either starting setup assistant or Company Portal
 #   for the user to complete migration. The onboarding process should be configured in Intune separately.
-# -------------------------------------------------------------------------------------------------------
 #########################################################################################################
 
-#region Configuration
-
-# Set the maximum deferral count for the migration prompt, set to 0 to disable deferrals
-# If the deferral count is reached, the Exit button will be disabled
-max_deferral_count=0
-deferral_count_file="/Library/Preferences/com.microsoft.intune_migration.deferral_count.plist"
-# Set if device is being migrated from another Intune tenant
-intune_migration=false
-# Set if Swift Dialog should be uninstalled after migration
-uninstall_swiftdialog=false
-# Reset office for the user, uses OfficeReset.com
-reset_office=false
-
-# Set to false if you do not want to blur the screen during dialog display
-blur_screen=true
-blur_screen_string="--blurscreen"
-# Set the font options for the dialog title
-title_font_options="shadow=0,name=SFProDisplay-Regular"
-# Banner colour
-banner_colour="blue"
-
-# Messages for the migration prompt and progress dialog
-migration_message_intune="Your device is scheduled to be migrated from **current Microsoft Intune tenant** to another **Microsoft Intune tenant**"
-migration_message_jamf="Your device is scheduled to be migrated from **Jamf** to **Microsoft Intune**"
-progress_message_intune="Your device is being migrated from one Microsoft Intune tenant to another"
-progress_message_jamf="Your device is being migrated from Jamf to Microsoft Intune"
-
-# URL of your Jamf Pro server
-JAMF_PRO_URL="https://yourenvironment.jamfcloud.com"
-# This should be a Jamf Pro user with the Jamf Pro Server Action 'Send Computer Unmanage Command' enabled and Jamf Pro Server Objects 'Computers' Read.
-USERNAME="migration_account"
-# Password for the above user
-PASSWORD="migration_account_password"
+# Replace these with your Jamf Pro details
+JAMF_PRO_URL="https://yourenvironment.jamfcloud.com"  # URL of your Jamf Pro server
+USERNAME="migration_account"                          # This should be a Jamf Pro user with the Jamf Pro Server Action 'Send Computer Unmanage Command' enabled and Jamf Pro Server Objects 'Computers' Read.
+PASSWORD="migration_account_password"                 # Password for the above user
 LOG="/Library/Logs/Microsoft/IntuneScripts/intuneMigration/intuneMigration.log"
-# Set to "classic" for (JSSResource) or new for (api) to use the classic or new API
-JAMF_API_VERSION="new"
-
-# Graph API details
-# Set the GRAPH_ENDPOINT to the appropriate Intune API endpoint
-GRAPH_ENDPOINT="https://graph.microsoft.com/v1.0/deviceManagement/managedDevices"
-# Set the client ID, client secret, and tenant ID for the Graph API
-CLIENT_ID=""
-CLIENT_SECRET=""
-TENANT_ID=""
-
-#endregion
-
-# Create deferred count file if it doesn't exist
-if [ ! -f "$deferral_count_file" ]; then
-  echo "Creating deferral count file..."
-  sudo defaults write "$deferral_count_file" deferral_count -int 0
-fi
-
-if [ $blur_screen = false ]; then
-  blur_screen_string=""
-fi
-
-#region Dialogs
-
-# Function to display message to sign in to Company Portal
-cp_sign_in_message() {
-  /usr/local/bin/dialog \
-    --bannertitle "Action Required: Sign in to Company Portal" \
-    --message "To complete your device setup, you must sign in to the Company Portal app using your **Entra (Microsoft)** credentials.\n\nFailure to sign in to Company Portal will result in the loss of access to corporate resources such as **e-Mail** and **other essential services**.\n\nWhen you close this dialog, Company Portal will be open your screen, click **Sign-in** and complete the process to avoid service disruptions." \
-    --button1text "Got it" \
-    $blur_screen_string \
-    --bannerimage colour=$banner_colour \
-    --titlefont "$title_font_options" \
-    --width 750 \
-    --height 450 \
-    --icon /Applications/Company\ Portal.app/Contents/Resources/AppIcon.icns
-}
-
-# Function to display "Waiting for Intune" message with spinner
-waiting_for_intune() {
-  /usr/local/bin/dialog \
-    --bannertitle "Status: Waiting for Intune" \
-    --message "Your device setup is in progress.\n\nWe're currently waiting for Intune to complete the necessary setup. This may take a few minutes.\n\nPlease keep this window open until setup is complete." \
-    $blur_screen_string \
-    --bannerimage colour=$banner_colour \
-    --titlefont "$title_font_options" \
-    --progress \
-    --width 750 \
-    --height 450 \
-    --icon /Applications/Company\ Portal.app/Contents/Resources/AppIcon.icns \
-    --no-buttons
-    --progress &
-  
-  # Capture the dialog process ID to close it later if needed
-  DIALOG_PID=$!
-}
-
-# Function to display message for ADE enrollment
-ade_enrollment_message() {
-  /usr/local/bin/dialog \
-    --bannertitle "Action Required: Complete Device Enrollment" \
-    --message "Your device is **ADE-enrolled** and requires additional setup to complete enrollment into **Intune**.\n\nPlease follow the setup assistant screens to sign in with your **Entra (Microsoft)** credentials. This process is necessary to gain access to corporate resources, including **e-Mail** and other essential services.\n\nWhen you close this dialog, the setup assistant will open. Follow the prompts to complete the enrollment process." \
-    --button1text "Got it" \
-    $blur_screen_string \
-    --bannerimage colour=$banner_colour \
-    --titlefont "$title_font_options" \
-    --width 750 \
-    --height 450 \
-    --icon /Applications/Company\ Portal.app/Contents/Resources/AppIcon.icns
-}
-
-# Function to prompt the user to start the migration
-prompt_migration() {
-
-    if [ "$intune_migration" = true ]; then
-        message=$migration_message_intune
-    else
-        message=$migration_message_jamf
-    fi
-
-    if [ $max_deferral_count -gt 0 ]; then
-        button2text="Defer"
-        deferral_message="\n\nYou can defer this migration up to **$max_deferral_count** times. After that, the Defer button will be disabled. \n\nYou have **$((max_deferral_count - DEFERRAL_COUNT))** deferral(s) remaining."
-    else
-        deferral_message=""
-        button2text="Exit"
-    fi
-
-  # Display the dialog with improved message text
-  /usr/local/bin/dialog \
-    --bannertitle "Prepare for Device Migration" \
-    --message "${message}.\n\nThis process will take approximately **20 minutes**, during which you will **not be able to use your Mac**.${deferral_message}" \
-    --button1text "Migrate" \
-    $( [[ $((DEFERRAL_COUNT)) -lt $((max_deferral_count)) || $((max_deferral_count)) -eq 0 ]] && echo "--button2text $button2text" ) \
-    $blur_screen_string \
-    --bannerimage colour=$banner_colour \
-    --titlefont "$title_font_options" \
-    --width 750 \
-    --height 450 \
-    --icon /Applications/Company\ Portal.app/Contents/Resources/AppIcon.icns
-
-  # Check which button was clicked based on the exit code
-  if [[ "$?" -eq 0 ]]; then
-    echo "User chose to migrate the device."
-    USER_READY=true
-  else
-    USER_READY=false
-  fi
-}
-
-#endregion
-
-#region Helper Functions
+JAMF_API_VERSION="new"     # Set to "classic" for (JSSResource) or new for (api) to use the classic or new API
 
 # Function to check if the device is managed by Jamf
 check_if_managed() {
-    if [ "$intune_migration" = true ]; then
-        if profiles -P | grep -q "Microsoft.Profiles.MDM"; then
-            echo "Checking if the device is managed by Intune..."
-        else
-            echo "Device is not managed by Intune. Exiting script."
-            exit 0
-        fi
-    elif [ "$intune_migration" = false ]; then
-        if profiles -P | grep -q "com.jamfsoftware"; then
-            echo "Device is managed by Jamf."
-        else
-            echo "Device is not managed by Jamf. Exiting script."
-            exit 0
-        fi
-    fi
+  if profiles -P | grep -q "com.jamfsoftware"; then
+    echo "Device is managed by Jamf."
+  else
+    echo "Device is not managed by Jamf. Exiting script."
+    exit 0
+  fi
 }
 
 function startLog() {
@@ -219,63 +67,6 @@ function startLog() {
     fi
 
     exec > >(tee -a "$LOG") 2>&1
-}
-
-# Function to check and install swiftDialog if not present
-install_swiftDialog() {
-  if [ ! -f "/usr/local/bin/dialog" ]; then
-    echo "swiftDialog not found. Installing swiftDialog..."
-    curl -L -o /tmp/dialog.pkg "https://github.com/swiftDialog/swiftDialog/releases/download/v2.5.2/dialog-2.5.2-4777.pkg"
-    sudo installer -pkg /tmp/dialog.pkg -target /
-    rm /tmp/dialog.pkg
-    echo "swiftDialog installed successfully."
-  else
-    echo "swiftDialog is already installed."
-  fi
-}
-
-uninstall_swiftDialog() {
-  if [ "$uninstall_swiftdialog" = true ]; then
-    echo "Uninstalling swiftDialog..."
-    sudo rm -f /usr/local/bin/dialog
-    sudo rm -r "/Library/Application Support/Dialog/"
-    sudo pkgutil --forget au.csiro.dialogcli
-  fi
-}
-
-uninstall_sidecar() {
-  echo "Uninstalling Sidecar..."
-  sidecar_app_path="/Library/Intune"
-  sidecar_ld_name="com.microsoft.intuneMDMAgent.daemon"
-  sidecar_la_name="com.microsoft.intuneMDMAgent"
-  sidecar_db_path="/Library/Application Support/Microsoft/Intune/SideCar"
-  sidecar_launchagent_path="/Library/LaunchAgents/$sidecar_la_name.plist"
-  sidecar_launchdaemon_path="/Library/LaunchDaemons/$sidecar_ld_name.plist"
-  console_user=$(/usr/bin/stat -f "%Su" /dev/console)
-  console_user_uid=$(/usr/bin/id -u "$console_user")
-
-  if [ -d "$sidecar_app_path" ]; then
-    rm -rf "$sidecar_app_path"
-  fi
-
-  if [ -d "$sidecar_db_path" ]; then
-    rm -rf "$sidecar_db_path"
-  fi
-
-  if [ -f "$sidecar_launchagent_path" ]; then
-    /bin/launchctl asuser "${console_user_uid}" /bin/launchctl unload -w  "$sidecar_launchagent_path"
-    rm -f "$sidecar_launchagent_path"
-  fi
-
-  if [ -f "$sidecar_launchdaemon_path" ]; then
-    # is it loaded?
-    if launchctl print "system/${sidecar_ld_name}" &> /dev/null ; then
-      /bin/launchctl unload "$sidecar_launchdaemon_path"
-    fi
-    rm -f "$sidecar_launchdaemon_path"
-  fi
-
-  killall "IntuneMdmAgent"
 }
 
 # Function to check if jq is installed, and if not, install it
@@ -321,6 +112,126 @@ check_and_install_jq() {
   fi
 }
 
+# Function to check and install swiftDialog if not present
+install_swiftDialog() {
+  if [ ! -f "/usr/local/bin/dialog" ]; then
+    echo "swiftDialog not found. Installing swiftDialog..."
+    curl -L -o /tmp/dialog.pkg "https://github.com/swiftDialog/swiftDialog/releases/download/v2.5.2/dialog-2.5.2-4777.pkg"
+    sudo installer -pkg /tmp/dialog.pkg -target /
+    rm /tmp/dialog.pkg
+    echo "swiftDialog installed successfully."
+  else
+    echo "swiftDialog is already installed."
+  fi
+}
+
+# Function to check and install Company Portal if not present
+install_cp() {
+  if [ ! -d "/Applications/Company Portal.app" ]; then
+    echo "Company Portal not found. Installing Company Portal..."
+    curl -L -o /tmp/cp.pkg "https://go.microsoft.com/fwlink?linkid=853070"
+    sudo installer -pkg /tmp/cp.pkg -target /
+    rm /tmp/cp.pkg
+    echo "Company Portal installed successfully."
+  else
+    echo "Company Portal is already installed."
+  fi
+}
+
+# Function to display message to sign in to Company Portal
+cp_sign_in_message() {
+  /usr/local/bin/dialog \
+    --bannertitle "Action Required: Sign in to Company Portal" \
+    --message "To complete your device setup, you must sign in to the Company Portal app using your **Entra (Microsoft)** credentials.\n\nFailure to sign in to Company Portal will result in the loss of access to corporate resources such as **e-Mail** and **other essential services**.\n\nWhen you close this dialog, Company Portal will be open your screen, click **Sign-in** and complete the process to avoid service disruptions." \
+    --button1text "Got it" \
+    --blurscreen \
+    --bannerimage colour=blue \
+    --titlefont shadow=1 \
+    --width 750 \
+    --height 450 \
+    --icon /Applications/Company\ Portal.app/Contents/Resources/AppIcon.icns
+}
+
+# Function to display "Waiting for Intune" message with spinner
+waiting_for_intune() {
+  /usr/local/bin/dialog \
+    --bannertitle "Status: Waiting for Intune" \
+    --message "Your device setup is in progress.\n\nWe're currently waiting for Intune to complete the necessary setup. This may take a few minutes.\n\nPlease keep this window open until setup is complete." \
+    --blurscreen \
+    --bannerimage colour=blue \
+    --titlefont shadow=1 \
+    --progress \
+    --width 750 \
+    --height 450 \
+    --icon /Applications/Company\ Portal.app/Contents/Resources/AppIcon.icns \
+    --no-buttons \
+    --progress &
+  
+  # Capture the dialog process ID to close it later if needed
+  DIALOG_PID=$!
+}
+
+# Function to display message for ADE enrollment
+ade_enrollment_message() {
+  /usr/local/bin/dialog \
+    --bannertitle "Action Required: Complete Device Enrollment" \
+    --message "Your device is **ADE-enrolled** and requires additional setup to complete enrollment into **Intune**.\n\nPlease follow the setup assistant screens to sign in with your **Entra (Microsoft)** credentials. This process is necessary to gain access to corporate resources, including **e-Mail** and other essential services.\n\nWhen you close this dialog, the setup assistant will open. Follow the prompts to complete the enrollment process." \
+    --button1text "Got it" \
+    --blurscreen \
+    --bannerimage colour=blue \
+    --titlefont shadow=1 \
+    --width 750 \
+    --height 450 \
+    --icon /Applications/Company\ Portal.app/Contents/Resources/AppIcon.icns
+}
+
+# Function to prompt the user to start the migration
+prompt_migration() {
+
+  # Display the dialog with improved message text
+  /usr/local/bin/dialog \
+    --bannertitle "Prepare for Device Migration" \
+    --message "Your device is scheduled to be migrated from **Jamf** to **Microsoft Intune**.\n\nThis process will take approximately **20 minutes**, during which you will **not be able to use your Mac**." \
+    --button1text "Migrate" \
+    --button2text "Exit" \
+    --blurscreen \
+    --bannerimage colour=blue \
+    --titlefont shadow=1 \
+    --width 750 \
+    --height 450 \
+    --icon /Applications/Company\ Portal.app/Contents/Resources/AppIcon.icns
+
+  # Check which button was clicked based on the exit code
+  if [[ "$?" -eq 0 ]]; then
+    echo "User is ready to start the migration."
+    return 0  # Proceed with migration
+  else
+    echo "User chose not to migrate at this time."
+    exit 1  # Exit the script
+  fi
+}
+
+# Function to start the migration dialog in progress mode
+start_progress_dialog() {
+  COMMAND_FILE="/tmp/dialog_command"
+  echo "Initializing migration..." > "$COMMAND_FILE"
+  /usr/local/bin/dialog \
+    --bannertitle "Device Migration in Progress" \
+    --icon /Applications/Company\ Portal.app/Contents/Resources/AppIcon.icns \
+    --bannerimage colour=blue \
+    --titlefont shadow=1 \
+    --message "Your device is being migrated from Jamf to Microsoft Intune. Please do not power off or disconnect your device during this process." \
+    --blurscreen \
+    --force \
+    --no-buttons \
+    --progress \
+    --width 750 \
+    --height 450 \
+    --commandfile "$COMMAND_FILE" &
+  
+  DIALOG_PID=$!
+}
+
 # Function to update the dialog progress bar and text via the command file
 update_progress() {
   local progress_value="$1"
@@ -332,60 +243,6 @@ update_progress() {
   
   # Add a small delay to ensure swiftDialog processes each update properly
   sleep 1
-}
-
-office_reset() {
-  if [ "$reset_office" = true ]; then
-    update_progress 30 "Resetting Office..."
-    echo "Resetting Office..."
-    curl -L -o /tmp/OfficeReset.pkg "https://office-reset.com/download/Microsoft_Office_Factory_Reset_1.9.1.pkg"
-    sudo installer -pkg /tmp/OfficeReset.pkg -target /
-    rm /tmp/OfficeReset.pkg
-  fi
-}
-
-# Function to start the migration dialog in progress mode
-start_progress_dialog() {
-  COMMAND_FILE="/tmp/dialog_command"
-  echo "Initializing migration..." > "$COMMAND_FILE"
-
-  if [ "$intune_migration" = true ]; then
-    message=$progress_message_intune
-  else
-    message=$progress_message_jamf
-  fi
-  
-  /usr/local/bin/dialog \
-    --bannertitle "Device Migration in Progress" \
-    --icon /Applications/Company\ Portal.app/Contents/Resources/AppIcon.icns \
-    --bannerimage colour=$banner_colour \
-    --titlefont "$title_font_options" \
-    --message "${message}. Please do not power off or disconnect your device during this process." \
-    $blur_screen_string \
-    --force \
-    --no-buttons \
-    --progress \
-    --width 750 \
-    --height 450 \
-    --commandfile "$COMMAND_FILE" &
-  
-  DIALOG_PID=$!
-}
-
-# Function to clean Company Portal app if needed
-clean_company_portal() {
-  sudo killall "Company Portal"
-
-  currentuser=`stat -f "%Su" /dev/console`
-  rm -rf /Users/"$currentuser"/Library/Saved\ Application\ State/com.microsoft.CompanyPortalMac.savedState
-  rm -rf /Users/"$currentuser"/Library/Application\ Support/com.microsoft.CompanyPortalMac
-  rm -rf /Users/"$currentuser"/Library/Application\ Support/com.microsoft.CompanyPortalMac.usercontext.info
-  su "$currentuser" -c "security delete-generic-password -l 'com.microsoft.adalcache'"
-  su "$currentuser" -c "security delete-generic-password -l 'enterpriseregistration.windows.net'"
-  su "$currentuser" -c "security delete-generic-password -l 'https://device.login.microsoftonline.com'"
-  su "$currentuser" -c "security delete-generic-password -l 'https://device.login.microsoftonline.com/' "
-  su "$currentuser" -c "security delete-generic-password -l 'https://enterpriseregistration.windows.net' "
-  su "$currentuser" -c "security delete-generic-password -l 'https://enterpriseregistration.windows.net/' "
 }
 
 # Function to completely remove Jamf framework
@@ -403,16 +260,19 @@ remove_jamf_framework() {
   fi
 }
 
-# Function to check and install the Intune Company Portal app if not present
-install_cp() {
-  if [ ! -d "/Applications/Company Portal.app" ]; then
-    echo "Company Portal not found. Installing Company Portal..."
-    curl -L -C - -o /tmp/cp.pkg "https://go.microsoft.com/fwlink?linkid=853070"
-    sudo installer -pkg /tmp/cp.pkg -target /
-    rm /tmp/cp.pkg
-    echo "Company Portal installed successfully."
+# Function to check if the device is ADE enrolled
+check_ade_enrollment() {
+  echo "Checking if the device is ADE enrolled..."
+
+  # Run profiles status to check for DEP enrollment
+  ade_status=$(profiles status -type enrollment 2>/dev/null | grep -i "Enrolled via DEP: Yes")
+
+  if [ -n "$ade_status" ]; then
+    echo "Device is ADE enrolled."
+    ADE_ENROLLED=true
   else
-    echo "Company Portal is already installed."
+    echo "Device is not ADE enrolled."
+    ADE_ENROLLED=false
   fi
 }
 
@@ -426,14 +286,22 @@ launch_company_portal() {
 EOF
 }
 
+# Function to renew profiles if the device is ADE enrolled
+renew_profiles() {
+  sudo profiles renew -type enrollment
+  echo "Profiles renewed."
+}
+
 # Function to get the serial number of the current Mac
 get_serial_number() {
   system_profiler SPHardwareDataType | awk '/Serial Number/ {print $4}'
 }
 
-#endregion
-
-#region Jamf API Functions
+# Function to obtain an authentication token
+get_auth_token() {
+  auth_token=$(curl -su "$USERNAME:$PASSWORD" -X POST "$JAMF_PRO_URL/api/v1/auth/token" | jq -r '.token')
+  echo "$auth_token"
+}
 
 # Function to get the computer_id from Jamf Pro based on serial number
 get_computer_id() {
@@ -446,12 +314,8 @@ get_computer_id() {
   echo "$computer_id"
 }
 
-# Function to obtain an authentication token
-get_auth_token() {
-  auth_token=$(curl -su "$USERNAME:$PASSWORD" -X POST "$JAMF_PRO_URL/api/v1/auth/token" | jq -r '.token')
-  echo "$auth_token"
-}
-
+# Function to unmanage a device from Jamf Pro using the new API,
+# then trigger a device check-in
 unmanage_device_jamf_new() {
     # Validate input parameters
     if [[ -z "$1" || -z "$2" ]]; then
@@ -488,6 +352,8 @@ unmanage_device_jamf_new() {
 
 }
 
+# Function to unmanage a device from Jamf Pro using the classic API,
+# then trigger a device check-in
 unmanage_device_jamf_classic() {
     # Validate input parameters
     if [[ -z "$1" || -z "$2" ]]; then
@@ -525,123 +391,12 @@ unmanage_device_jamf_classic() {
 
 }
 
-#endregion
-
-#region Intune API Functions
-
-get_graph_auth_token() {
-    local response
-
-    echo "DEBUG: Getting access token..." >&2
-
-    response=$(curl -s -X POST \
-        -d "client_id=$CLIENT_ID" \
-        -d "scope=https://graph.microsoft.com/.default" \
-        -d "client_secret=$CLIENT_SECRET" \
-        -d "grant_type=client_credentials" \
-        "https://login.microsoftonline.com/$TENANT_ID/oauth2/v2.0/token")
-        
-    if echo "$response" | jq -e '.error' >/dev/null; then
-        echo "Failed to get access token: $response" >&2
-        exit 1
-    else
-        echo "$response" | jq -r '.access_token'
-    fi
-}
-
-get_intune_device_id() {
-    local serial_number="$1"
-    local access_token="$2"  # Access token should be passed as an argument
-    local response
-
-    echo "DEBUG: Getting device ID..." >&2
-
-    # Ensure the access token is set
-    if [ -z "$access_token" ]; then
-        echo "Error: Access token is missing!" >&2
-        exit 1
-    fi
-
-    # Ensure GRAPH_ENDPOINT is set
-    if [ -z "$GRAPH_ENDPOINT" ]; then
-        echo "Error: GRAPH_ENDPOINT is not set!" >&2
-        exit 1
-    fi
-
-    # Correct Authorization header and properly format the filter query
-    response=$(curl -s -X GET \
-        -H "Authorization: Bearer $access_token" \
-        -H "Content-Type: application/json" \
-        "$GRAPH_ENDPOINT?\$filter=serialNumber%20eq%20'$serial_number'")
-
-    if echo "$response" | jq -e '.error' >/dev/null; then
-        echo "Failed to get device ID: $response" >&2
-        exit 1
-    else
-        # verify we only have one device
-        if [ $(echo "$response" | jq -r '.value | length') -ne 1 ]; then
-            echo "Error: Multiple devices found for serial number: $serial_number" >&2
-            exit 1
-        fi
-        echo "$response" | jq -r '.value[0].id'
-    fi
-}
-
-unmanage_device_from_intune() {
-    local device_id="$1"
-    local access_token="$2"
-    local response
-
-    echo "DEBUG: Unmanaging device..." >&2
-
-    update_progress 50 "Removing Intune management..."
-
-    # Ensure required parameters are provided
-    if [ -z "$device_id" ] || [ -z "$access_token" ]; then
-        echo "Error: Missing device ID or access token!" >&2
-        exit 1
-    fi
-
-    # Send the unmanage device command
-    response=$(curl -s -X DELETE \
-        -H "Authorization: Bearer $access_token" \
-        "$GRAPH_ENDPOINT/$device_id")
-
-    if echo "$response" | jq -e '.error' >/dev/null; then
-        echo "Failed to unmanage device: $response" >&2
-        exit 1
-    else
-        echo "Device successfully unmanaged."
-    fi
-}
-
-#endregion
-
-#region MDM Profile Removal
-
-# Function to check if the device is ADE enrolled
-check_ade_enrollment() {
-  echo "Checking if the device is ADE enrolled..."
-
-  # Run profiles status to check for DEP enrollment
-  ade_status=$(profiles status -type enrollment 2>/dev/null | grep -i "Enrolled via DEP: Yes")
-
-  if [ -n "$ade_status" ]; then
-    echo "Device is ADE enrolled."
-    ADE_ENROLLED=true
-  else
-    echo "Device is not ADE enrolled."
-    ADE_ENROLLED=false
-  fi
-}
-
+# Function to wait until management profile is removed...
 wait_for_management_profile_removal() {
   echo "Waiting for MDM management profile removal..."
   local timeout=1800
   local interval=5
   local elapsed=0
-
-  update_progress 70 "Waiting for MDM management profile removal..."
 
   while true; do
     # Capture the enrollment profiles output.
@@ -666,178 +421,74 @@ wait_for_management_profile_removal() {
   done
 }
 
-# Function to renew profiles if the device is ADE enrolled
-renew_profiles() {
-  sudo profiles renew -type enrollment
-  echo "Profiles renewed."
-}
-
-# Function to unmanage the device from Intune
-remove_intune_management() {
-  update_progress 50 "Removing Intune management..."
-  echo "Removing Intune management..."
-  sudo profiles -R -p "Microsoft.Profiles.MDM"
-  echo "Intune management removed."
-}
-
-#endregion
-
 ############################################################
 ##
 ## Main Script Execution Begins Here
 ##
 #########################################
 
-#region Main Script Execution
-
 # Start Logging before we do anything else...
 startLog
 
-# Flag to track ADE enrollment
-ADE_ENROLLED=false
-
-# Flag to track user readiness
-USER_READY=false
-
-# Check if the device is managed
+# Check if device is Jamf-managed
 check_if_managed
 
-# Install swiftDialog if needed
+# Check if ADE enrolled and set state so we can use it later
+check_ade_enrollment
+
 # Install dependencies if needed
 install_cp
 install_swiftDialog
 check_and_install_jq
 
-#Launch initial migration prompt
-DEFERRAL_COUNT=$(defaults read "$deferral_count_file" deferral_count)
+# Prompt user to migrate
+prompt_migration  # If they exit here, we do nothing and exit
 
-prompt_migration
-
-DEFERRAL_COUNT=$((DEFERRAL_COUNT + 1))
-
-# Exit script if user chose not to migrate
-if [ "$USER_READY" = false ]; then
-  echo "User chose to exit the migration process. Exiting script."
-    # Inrement deferral count
-    if [ $max_deferral_count -eq 0 ]; then
-      echo "Deferral count is disabled. Exiting script."
-      exit 0
-    fi
-
-    sudo defaults write "$deferral_count_file" deferral_count -int "$DEFERRAL_COUNT"
-    echo "Deferral count not reached: $DEFERRAL_COUNT"
-    exit 0
-fi
-
-#Launch actual migration dialog
+# Start migration dialog
 start_progress_dialog
 
-# Call the function to reset office
-office_reset
+# Now that user has agreed, fetch Jamf API details
+serial_number=$(get_serial_number)
+echo "Serial Number: $serial_number"
+auth_token=$(get_auth_token)
+echo "Auth Token: $auth_token"
+computer_id=$(get_computer_id "$serial_number" "$auth_token")
+echo "Computer ID: $computer_id"
 
-# Check ADE enrollment before unmanaging the device
-check_ade_enrollment
-
-if [ "$intune_migration" = false ]; then
-  # Now that user has agreed, fetch Jamf API details
-  serial_number=$(get_serial_number)
-  echo "Serial Number: $serial_number"
-  auth_token=$(get_auth_token)
-  echo "Auth Token: $auth_token"
-  computer_id=$(get_computer_id "$serial_number" "$auth_token")
-  echo "Computer ID: $computer_id"
-
-  # If computer_id is found, unmanage and remove Jamf
-  if [ -n "$computer_id" ]; then
-  # Call unmanage function based on API version using case statement
-    case $JAMF_API_VERSION in
-        classic)
-            unmanage_device_jamf_classic "$computer_id" "$auth_token"
-            
-            ;;
-        new)
-            unmanage_device_jamf_new "$computer_id" "$auth_token"
-            ;;
-        *)
-            echo "Error: Invalid JAMF_API_VERSION specified. Must be 'classic' or 'new'" >&2
-            exit 1
-            ;;
-    esac
-  else
-      echo "Computer ID not found for Serial Number: $serial_number"
-      exit 1
-  fi
-
-  # Wait for management profile to be removed
-  wait_for_management_profile_removal
+# If computer_id is found, unmanage and remove Jamf
+if [ -n "$computer_id" ]; then
+# Call unmanage function based on API version using case statement
+  case $JAMF_API_VERSION in
+      classic)
+          unmanage_device_jamf_classic "$computer_id" "$auth_token"
+          
+          ;;
+      new)
+          unmanage_device_jamf_new "$computer_id" "$auth_token"
+          ;;
+      *)
+          echo "Error: Invalid JAMF_API_VERSION specified. Must be 'classic' or 'new'" >&2
+          exit 1
+          ;;
+  esac
 else
-  if [ $ADE_ENROLLED = true ]; then
-    if [ -z "$CLIENT_ID" ] || [ -z "$CLIENT_SECRET" ] || [ -z "$TENANT_ID" ]; then
-      echo "GRAPH API details are missing!" >&2
-      exit 1
-    else
-      serial_number=$(get_serial_number)
-      echo "Serial Number: $serial_number"
-      # Get the device ID from Intune
-      access_token=$(get_graph_auth_token)
-      device_id=$(get_intune_device_id "$serial_number" "$access_token")
-      echo "Device ID: $device_id"
-
-      # Unmanage the device from Intune
-      unmanage_device_from_intune "$device_id" "$access_token"
-
-      # Clean up the Company Portal app
-      clean_company_portal
-
-      # Wait for management profile to be removed
-      wait_for_management_profile_removal
-    fi
-  else
-    remove_intune_management
-    clean_company_portal
-  fi
+    echo "Computer ID not found for Serial Number: $serial_number"
+    exit 1
 fi
 
-if [ "$intune_migration" = true ]; then
-  uninstall_sidecar
-  update_progress 90 "Device removed from Intune, now starting Intune Migration"
-  sleep 2
-else
-  update_progress 90 "Device removed from Jamf, now starting Intune Migration"
-  sleep 2
-fi
+# Wait for management profile to be removed
+wait_for_management_profile_removal
 
-# Close Dialog and any remaining jamf processes
-killall Dialog
-if [ "$intune_migration" = false ]; then
-  killall jamf
-fi
-
-# If the device was ADE enrolled, renew profiles
+# If ADE enrolled, show message + renew profiles; else prompt for CP sign-in
 if [ "$ADE_ENROLLED" = true ]; then
-
-    # Show end user dialog about ADE enrollment process
     ade_enrollment_message
-
-    # Renew profiles to trigger Intune setup
     renew_profiles
-
-    # Show waiting for Intune dialog, this will remain open until Intune setup is complete and the onboarding script runs
     sleep 5
     waiting_for_intune
 else
-
-    # Show sign-in message for Company Portal
     cp_sign_in_message
-
-    # Launch Company Portal
     launch_company_portal
 fi
 
-# Uninstall swiftDialog
-uninstall_swiftDialog
 
-# Clean up the deferral count file
-sudo rm -f "$deferral_count_file"
-
-#endregion
+exit 0

--- a/macOS/Tools/Migration/intuneMigrationSample.sh
+++ b/macOS/Tools/Migration/intuneMigrationSample.sh
@@ -37,7 +37,7 @@
 max_deferral_count=0
 deferral_count_file="/Library/Preferences/com.microsoft.intune_migration.deferral_count.plist"
 # Set if device is being migrated from another Intune tenant
-intune_migration=true
+intune_migration=false
 # Set if Swift Dialog should be uninstalled after migration
 uninstall_swiftdialog=false
 # Reset office for the user, uses OfficeReset.com

--- a/macOS/Tools/Migration/readme.md
+++ b/macOS/Tools/Migration/readme.md
@@ -1,4 +1,12 @@
-# Intune Migration Script
+# Migration Script
+
+There are mutliple scripts in this repository. The scripts are designed to help you migrate from Jamf to Intune or from Intune to Intune. The scripts are designed to be run on macOS devices and require administrative privileges.
+
+[Jamf to Intune Migration Script](#jamf-to-intune-migration-script)
+
+[Intune to Intune Migration Script](#intune-to-intune-migration-script)
+
+# Intune To Jamf Migration Script
 
 This script facilitates the migration of macOS devices from Jamf to Microsoft Intune. It handles the **removal of the Jamf framework**, **installation** of the Microsoft Intune Company Portal app (if required), and ensures a smooth transition to Intune. The script uses **swiftDialog** for user interactions and provides clear progress and status messages throughout the migration.
 
@@ -144,13 +152,209 @@ https://github.com/user-attachments/assets/5669bd8d-7642-4321-bc46-cd38b97e28a6
 
 ---
 
-## Feedback
+# Intune To Intune Migration Script
+
+This script facilitates the migration of macOS devices from Microsoft Intune to Microsoft Intune. It handles the **removal of the Intune Managment**, **removal of Sidecar**, **installation** of the Microsoft Intune Company Portal app (if required), and ensures a smooth transition to Intune. The script uses **swiftDialog** for user interactions and provides clear progress and status messages throughout the migration.
+
+---
+
+https://github.com/user-attachments/assets/5669bd8d-7642-4321-bc46-cd38b97e28a6
+
+## General Usage
+
+1. **Make the Script Executable**  
+   ```bash
+   chmod +x intuneMigration.sh
+   ```
+
+2. **Run the Script**  
+   ```bash
+   sudo ./intuneMigration.sh
+   ```
+
+3. **Follow On-Screen Prompts**  
+   - The script will detect if the device is managed by Intune. If not, it exits.  
+   - If it detects Intune, it installs `swiftDialog` (if missing) and then prompts the user to either **Migrate** or **Exit**.  
+   - If **Exit** is chosen, the script cancels and leaves Intune in place.  
+   - If **Migrate** is chosen, the script proceeds to remove the Intune and prepare the device for another Intune tenant.
+
+---
+
+## Prerequisites
+
+1. **Device Enrollment**  
+   - If your organization uses **Apple Business Manager (ABM)** and **ADE** (Automated Device Enrollment), ensure the device is assigned to Intune in ABM before starting.  
+
+2. **swiftDialog**  
+   - The script will install **swiftDialog** automatically if it’s not already present.  
+
+3. **Internet Connectivity**  
+   - Required to download the Microsoft Intune Company Portal and any other dependencies.
+
+4. **Intune Enrollment Experience**
+   - When the screen shows 'Status: Waiting for Intune', this is where this script has finished performing actions. At this stage we are waiting for the Intune enrollment actions to begin. This is on YOU to configure and deploy. If you just deploy this script it will wait on this screen forever. An example can be found in [swiftDialog onboarding sample](https://github.com/microsoft/shell-intune-samples/tree/master/macOS/Config/Swift%20Dialog%20(PKG)).
+
+5. **Graph API Permissions**  
+   - Ensure the script has the necessary permissions to call the Graph API for unmanaging the device. This typically requires **DeviceManagementManagedDevices.ReadWrite.All** permissions. To do this, you need to create an **Azure AD App** and assign the required permissions. To do this, follow the steps below:
+
+      1. Go to Azure Portal
+         - Navigate to: https://portal.azure.com
+         - Open Azure Active Directory > App registrations
+
+      2. Register a New App
+         - Click + New registration
+         - Name your app (e.g., IntuneDeviceMigration)
+         - Set Supported account types (usually “Single tenant” is fine)
+         - Click Register
+
+      3. Create a Client Secret
+         - Go to Certificates & secrets
+         - Click + New client secret
+         - Add a description and expiry, then Copy the value and save it somewhere safe
+
+      4. Add Graph API Permissions
+         - Go to API permissions > + Add a permission
+         - Choose Microsoft Graph
+         - Select Application permissions
+         - Search for and add: `DeviceManagementManagedDevices.ReadWrite.All`
+
+      5. Grant Admin Consent
+         - Still under API permissions, click Grant admin consent for your tenant
+
+      6. Save App Info for Use in Scripts
+
+      You’ll need the following values:
+         - Tenant ID
+         - Client ID
+         - Client Secret (from step 3)
+
+---
+
+## Features
+
+1. **User Prompts via `swiftDialog`**  
+   - Displays clear dialogs to guide the user through the migration.  
+   - Provides progress updates during the removal and installation steps.
+
+2. **Automatic Intune Removal**  
+   - Unmanages the device via Graph API calls and removes Intune only after user confirmation.
+
+3. **ADE Enrollment Handling**  
+   - If the device is **ADE-enrolled**, the script renews the device’s profiles and launches Apple’s Setup Assistant steps as needed.
+
+4. **Company Portal Installation**  
+   - Checks if **Microsoft Intune Company Portal** is installed. Installs it if missing.
+
+5. **Real-Time Progress Updates**  
+   - Uses progress bars (via `swiftDialog`) to keep the user informed.
+
+6. **Graceful Cleanup**  
+   - Kills any leftover `Dialog` processes as needed, preventing orphaned processes.
+
+---
+
+## Configuration Options
+
+- **Graph API Details**  
+  - Inside the script, you can edit your `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` to point to the correct Intune instance.  
+- **Script Functions**  
+  - The script is modularized into functions (e.g., `check_if_managed`, `remove_intune_management`, etc.), which you can rearrange or customize for your environment.
+- **max_deferral_count** 
+  - Allows you to set the maximum number of deferrals for the user. The default is 0.
+- **uninstall_swiftdialog** 
+  - The script will uninstall `swiftDialog` automatically if set to true.
+- **reset_office** 
+  - The script will reset `Microsoft Office` automatically if set to true using office-reset.com
+- **blur_screen** 
+  - SwiftDialog will blur the screen by default. Can be set to false if you want to disable this feature.
+- **title_font_options** 
+  - Allows you to set the font options for the title. The default is "shadow=0,name=SFProDisplay-Regular".
+- **banner_colour** 
+  - Allows you to set the banner colour. The default is "blue".
+- **migration_message_intune** 
+  - Allows you to set the migration message.
+- **progress_message_intune**
+   - Allows you to set the progress message.
+
+---
+
+## What the Script Does
+
+1. **Checks Intune Management**  
+   - Looks for `Microsoft.Profiles.MDM` profiles. If not present, it exits immediately.
+
+2. **Installs `swiftDialog`** (if needed)  
+   - Downloads and installs `swiftDialog` to provide user prompts.
+
+3. **Prompts the User to Migrate**  
+   - Presents a dialog with the option to **Migrate** or **Exit**.  
+   - If the user exits, the script ends (no changes made to Jamf).
+
+4. **Removes Intune** (After User Consent)  
+   - Obtains the **Graph API auth token**, looks up the **serial number**, then “unmanages” the device through Graph API.  
+   - Removes **Sidecar** to fully clean up before enrollment to a new tenant.
+
+5. **Installs or Validates Company Portal**  
+   - Checks if **Company Portal** is installed.  
+   - If not, downloads and installs it from Microsoft.
+
+6. **Checks ADE Enrollment**  
+   - Determines if the Mac is enrolled via **ADE (DEP)**.
+
+7. **Handles ADE and Profile Renewals**  
+   - If ADE-enrolled, prompts the user to complete Setup Assistant screens, then **renews** the device’s profiles.  
+   - Shows a **“waiting for Intune”** dialog until the user completes the ADE steps.
+
+8. **Non-ADE Flow**  
+   - If not ADE-enrolled, guides the user to **sign in to Company Portal** for Intune onboarding.
+
+9. **Progress Dialog and Cleanup**  
+   - Provides real-time status updates via a progress dialog.  
+   - Ends by cleaning up `Dialog` processes.
+
+---
+
+## Testing
+
+1. **Local Testing**  
+   - Run the script on a test Mac enrolled in Intune to verify that the framework is removed and Intune enrollment steps appear.  
+
+2. **User Experience**  
+   - Confirm that the user sees dialogs at the correct steps (migration prompt, progress bar, sign-in prompt).  
+   - Validate that exiting from the first prompt really does leave Intune in place.
+
+3. **Network/Connectivity**  
+   - Ensure the test Mac can reach the necessary endpoints (Intune, Microsoft CDN for Company Portal, etc.).
+
+---
+
+## Deployment
+
+- **Intune Script**  
+  - You can host this script in Intune and assign to devices that should migrate.  
+  - Once the user clicks “Run,” they’ll receive the migration prompt.
+
+- **Manual Execution**  
+  - SSH into the Mac or run the script locally with `sudo ./intuneMigration.sh`.
+
+---
+
+## Logs
+
+- Logs are saved to:  
+  `/Library/Logs/Microsoft/IntuneScripts/intuneMigration/intuneMigration.log`
+
+  This includes status messages, API responses, and installation details. Review it if you encounter issues.
+
+---
+
+# Feedback
 
 For questions or feedback, please reach out to:
 - **Neil Johnson**: neiljohn@microsoft.com
 
 ---
 
-## Disclaimer
+# Disclaimer
 
 This script is provided **“AS IS”** without warranty of any kind. Microsoft disclaims all implied warranties, including, without limitation, any implied warranties of merchantability or fitness for a particular purpose. The entire risk arising out of the use or performance of this script remains with you.


### PR DESCRIPTION
## What does this PR do?

This PR introduces a significant update to the intuneMigration.sh script, adding support for doing Intune -> Intune migrations, reset Office and allow users to defer the migration.


## Key changes
### Added support for Intune-to-Intune migration
- The script now detects if the device is migrating from one Intune tenant to another.
- Separate logic for removing the Intune management profile rather than Jamf.

### Added deferral mechanism for migration prompt
- Users can now defer migration up to a configurable number of times `max_deferral_count`.
- Stores deferral count in `/Library/Preferences/com.microsoft.intune_migration.deferral_count.plist`.

### Uninstalls swiftDialog after migration (optional)
- Ensures that swiftDialog is only used temporarily for UI prompts and removed after migration.

### Automated Office Reset (optional)
- Uses OfficeReset.com to clear credentials and reset Office applications during migration.

## How to test this PR
1. Deploy script to an Intune managed Mac.
2. Configure the `max_deferral_count` and test deferred migrations.
3. Configure `uninstall_swiftdialog` to test swift dialog removal.
4. Configure `reet_office` to test Office reset.
5. Confirm that:
    - User deferral is active
    - Company Portal is properly reset
    - Office credentials are reset
    - swift dialog uninstalls post-migration