### PR TITLE
Publish script to set default Office/Outlook apps

### DIFF
--- a/macOS/Apps/Microsoft 365 Apps for Mac/Set Default Apps/readme.md
+++ b/macOS/Apps/Microsoft 365 Apps for Mac/Set Default Apps/readme.md
@@ -1,0 +1,65 @@
+# Set Microsoft Office as Default Apps Script
+
+This script automates setting Microsoft Word, Excel, PowerPoint, and Outlook as the default handlers for their respective document types and URL schemes on macOS. It is designed for deployment via [Microsoft Intune](https://learn.microsoft.com/mem/intune/apps/macos-shell-scripts).
+
+## Features
+
+- Detects and installs [`utiluti`](https://github.com/scriptingosx/utiluti) v1.1 if not present.
+- Detects the current console (GUI) user and applies associations in their context.
+- Associates common Office file types (Word, Excel, PowerPoint) with the corresponding Microsoft app.
+- Sets Outlook as the default handler for email-related document types and URL schemes (e.g., `mailto:`).
+- Logs all actions to `/Library/Logs/IntuneScripts/setOfficeDefaultApps/setOfficeDefaultApps.log`.
+
+## Requirements
+
+- macOS 13 (Ventura) or later (tested up to Sonoma).
+- Must be run as root (e.g., via Intune, Jamf, or sudo).
+- Microsoft Office apps (Word, Excel, PowerPoint, Outlook) must be installed in `/Applications`.
+- Internet access to download `utiluti` if not already installed.
+
+## Usage
+
+Deploy or run the script as root. For Intune deployment instructions, see:  
+[Use shell scripts on macOS devices in Intune](https://learn.microsoft.com/mem/intune/apps/macos-shell-scripts)
+
+To run manually:
+
+```sh
+sudo ./setOfficeDefaultApps.sh
+```
+
+The script will:
+
+1. Ensure `utiluti` is installed.
+2. Detect the logged-in console user.
+3. Set default app associations for Office file types and email schemes for that user.
+
+## File Associations Set
+
+- **Word:** `.doc`, `.docx`, `.dotx`, `.rtf`
+- **Excel:** `.xls`, `.xlsx`, `.csv`
+- **PowerPoint:** `.ppt`, `.pptx`, `.ppsx`
+- **Outlook:** `.ics`, `.eml`, `.email`, `mailto:`, `message:`
+
+## Logging
+
+All output is logged to:
+
+```
+/Library/Logs/IntuneScripts/setOfficeDefaultApps/setOfficeDefaultApps.log
+```
+
+## Exit Codes
+
+- `0`: Success
+- `1`: Error (e.g., not run as root, missing Office app, or no console user)
+
+## Support & Disclaimer
+
+This script is provided as-is and is not covered under any Microsoft standard support program or service. Use at your own risk. For feedback or issues, contact neiljohn@microsoft.com.
+
+---
+
+**Related:**  
+- [`setOfficeDefaultApps.sh`](setOfficeDefaultApps.sh)
+- [utiluti GitHub](https://github.com/scriptingosx/utiluti)

--- a/macOS/Apps/Microsoft 365 Apps for Mac/Set Default Apps/setOfficeDefaultApps.sh
+++ b/macOS/Apps/Microsoft 365 Apps for Mac/Set Default Apps/setOfficeDefaultApps.sh
@@ -1,0 +1,164 @@
+#!/bin/zsh
+#set -x
+
+############################################################################################
+##
+## Script to install **utiluti** (if required) and set Microsoft Office / Outlook
+## as the default handler for all Office-related document types and URL schemes.  
+## Tested on macOS 14 (Sonoma) and macOS 13 (Ventura); requires utiluti ≥ 1.1.
+##
+## VER 1.0.0
+##
+## Change Log
+##
+## 2025-04-25   – Initial public release  
+##              • Added detection / silent install of utiluti v1.1  
+##              • Added console-user detection and *launchctl asuser* wrapper  
+##              • Added explicit *.csv* → Excel association (`ext set csv …`)  
+##              • Added verbose tracing (`set -x`) and unified startLog function  
+##
+############################################################################################
+##
+## Copyright © 2025 Microsoft Corporation. All rights reserved.
+## Scripts are not covered under any Microsoft standard support program or service.
+## THE SCRIPTS ARE PROVIDED **“AS IS”** WITHOUT WARRANTY OF ANY KIND. Microsoft disclaims
+## all implied warranties including, without limitation, any implied warranties of
+## merchantability or fitness for a particular purpose. The entire risk arising out of
+## the use or performance of the scripts and documentation remains with you. In no
+## event shall Microsoft, its authors, or anyone else involved in the creation,
+## production, or delivery of the scripts be liable for any damages whatsoever
+## (including, without limitation, damages for loss of business profits, business
+## interruption, loss of business information, or other pecuniary loss) arising out
+## of the use of or inability to use the scripts or documentation, even if Microsoft
+## has been advised of the possibility of such damages.
+##
+## Feedback / Issues: neiljohn@microsoft.com
+##
+############################################################################################
+
+################################################################################
+#  CONFIG
+################################################################################
+UTILUTI_PATH="/usr/local/bin/utiluti"
+UTILUTI_PKG_URL="https://github.com/scriptingosx/utiluti/releases/download/v1.1/utiluti-1.1.pkg"
+TMP_PKG="/tmp/utiluti.pkg"
+LOGFILE="/Library/Logs/IntuneScripts/setOfficeDefaultApps/setOfficeDefaultApps.log"
+
+WORD_APP="/Applications/Microsoft Word.app"
+EXCEL_APP="/Applications/Microsoft Excel.app"
+POWERPOINT_APP="/Applications/Microsoft PowerPoint.app"
+OUTLOOK_APP="/Applications/Microsoft Outlook.app"
+
+################################################################################
+#  HELPERS
+################################################################################
+
+########################################
+# startLog – write to file *and* STDOUT
+########################################
+function startLog() {
+
+    ###################################################
+    ###################################################
+    ##
+    ##  start logging – output to log file and STDOUT
+    ##
+    ####################
+    ####################
+
+    logandmetadir=$(dirname "$LOGFILE")  # Determine directory from LOGFILE
+    if [[ ! -d "$logandmetadir" ]]; then
+        ## Creating metadirectory
+        echo "$(date) | Creating [$logandmetadir] to store logs"
+        mkdir -p "$logandmetadir"
+    fi
+
+    exec > >(tee -a "$LOGFILE") 2>&1  # Use LOGFILE variable
+}
+
+# Find the GUI (console) user – ignore the background 'loginwindow' pseudo-user
+consoleUser=$(
+  scutil <<< "show State:/Users/ConsoleUser" \
+  | awk '/Name :/ && $3 != "loginwindow" { print $3 }'
+)
+if [[ -z "$consoleUser" ]]; then
+  echo ">>> No console user logged in – cannot set per-user defaults. Exiting."  # Replace _log usage with echo
+  exit 0
+fi
+consoleUID=$(id -u "$consoleUser")
+
+# Wrapper that runs utiluti *as the console user* and shows the exact command
+run_utiluti() {
+  launchctl asuser "$consoleUID" sudo -u "$consoleUser" "$UTILUTI_PATH" "$@"   # quote $@
+}
+
+################################################################################
+#  MAIN
+################################################################################
+# zsh‑compatible “safe shell” options
+set -e          # abort on error
+set -u          # abort on undefined variable
+set -o pipefail # abort if any command in a pipeline fails
+
+# Require root
+if [[ $EUID -ne 0 ]]; then
+  echo ">>> This script must be run as root."
+  exit 1
+fi
+
+# Turn on x‑trace *after* variables are defined to keep output readable
+# set -x
+
+startLog
+
+# 1. Ensure utiluti is present
+if [[ ! -x "$UTILUTI_PATH" ]]; then
+  echo ">>> utiluti not found – installing…"
+  curl -fL --retry 3 --silent --show-error -o "$TMP_PKG" "$UTILUTI_PKG_URL"
+  installer -pkg "$TMP_PKG" -target /
+  rm "$TMP_PKG"
+  hash -r       # refresh binary cache for the current shell
+else
+  echo ">>> utiluti already installed."
+fi
+
+# 2. Verify Office apps exist
+for APP in "$WORD_APP" "$EXCEL_APP" "$POWERPOINT_APP" "$OUTLOOK_APP"; do
+  [[ -d "$APP" ]] || { echo ">>> ERROR: $APP not found."; exit 1; }  # Replace _log usage with echo
+done
+
+# 3. Resolve bundle IDs (needed by utiluti)
+WORD_BID=$(mdls -name kMDItemCFBundleIdentifier -r "$WORD_APP")
+EXCEL_BID=$(mdls -name kMDItemCFBundleIdentifier -r "$EXCEL_APP")
+PPT_BID=$(mdls -name kMDItemCFBundleIdentifier -r "$POWERPOINT_APP")
+OUTLOOK_BID=$(mdls -name kMDItemCFBundleIdentifier -r "$OUTLOOK_APP")
+
+################################################################################
+#  Office associations
+################################################################################
+# Word
+run_utiluti type set com.microsoft.word.doc                         "$WORD_BID"
+run_utiluti type set org.openxmlformats.wordprocessingml.document   "$WORD_BID"
+run_utiluti type set org.openxmlformats.wordprocessingml.template   "$WORD_BID"
+run_utiluti type set public.rtf                                     "$WORD_BID"
+
+# Excel
+run_utiluti type set com.microsoft.excel.xls                        "$EXCEL_BID"
+run_utiluti type set org.openxmlformats.spreadsheetml.sheet         "$EXCEL_BID"
+run_utiluti type set public.comma-separated-values-text             "$EXCEL_BID"
+
+# PowerPoint
+run_utiluti type set com.microsoft.powerpoint.ppt                   "$PPT_BID"
+run_utiluti type set org.openxmlformats.presentationml.presentation "$PPT_BID"
+run_utiluti type set org.openxmlformats.presentationml.slideshow    "$PPT_BID"
+
+# Outlook (documents & URL schemes)
+run_utiluti type set com.apple.ical.ics         "$OUTLOOK_BID"
+run_utiluti type set com.apple.mail.email       "$OUTLOOK_BID"
+run_utiluti type set public.email-message       "$OUTLOOK_BID"
+run_utiluti url  set mailto                     "$OUTLOOK_BID"
+run_utiluti url  set message                    "$OUTLOOK_BID"
+
+################################################################################
+echo ">>> All defaults have been successfully set for user $consoleUser."  # Replace _log usage with echo
+exit 0


### PR DESCRIPTION
Set's Office apps to be default for:

- **Word:** `.doc`, `.docx`, `.dotx`, `.rtf`
- **Excel:** `.xls`, `.xlsx`, `.csv`
- **PowerPoint:** `.ppt`, `.pptx`, `.ppsx`
- **Outlook:** `.ics`, `.eml`, `.email`, `mailto:`, `message:`