### PR TITLE
Fixing ABM DEP check bug

### DIFF
--- a/macOS/Config/Uninstall Apple Bloatware Apps/UninstallAppleBloatwareApps.zsh
+++ b/macOS/Config/Uninstall Apple Bloatware Apps/UninstallAppleBloatwareApps.zsh
@@ -116,7 +116,7 @@ echo ""
 if [ "$abmcheck" = true ]; then
   echo "$(date) | Checking MDM Profile Type"
   profiles status -type enrollment | grep "Enrolled via DEP: Yes"
-  if [ ! $? == 0 ]; then
+  if [[ ! $? == 0 ]]; then
     echo "$(date) | This device is not ABM managed"
     exit 0;
   else


### PR DESCRIPTION
This statement results in the script failing. Because of the single brackets, ZSH is invoking the history expansion operator `!` instead of performing negation on the exit code check `?$ == 0`

`if [ ! $? == 0 ]; then
    echo "$(date) | This device is not ABM managed"
    exit 0;
  else`

Using the double brackets fixes the problem and the script runs fine:
`if [[ ! $? == 0 ]]; then
    echo "$(date) | This device is not ABM managed"
    exit 0;
  else`
  
Double brackets aren't POSIX compliant, but I don't think it matters for this particular script?