### PR TITLE
Fix open issues: #167, #139, #140, #148, #201

### DIFF
--- a/macOS/Apps/Google Drive/readme.md
+++ b/macOS/Apps/Google Drive/readme.md
@@ -1,12 +1,34 @@
-# Script to Enable Screen Sharing
+# Google Drive Installation Script for macOS
 
-This script is an example to show how to use [Intune Shell Scripting](https://docs.microsoft.com/en-us/mem/intune/apps/macos-shell-scripts) to enable screen sharing. In this case the script will enable screen sharing for Administrators only.
+This script automates the deployment of [Google Drive for desktop](https://www.google.com/drive/download/) on macOS devices through Microsoft Intune. It downloads the latest Google Drive `.dmg` from Google's official distribution source and installs it.
 
-## Quick Run
+## Features
 
-```
-sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/microsoft/shell-intune-samples/master/Misc/enableScreenSharing/enableScreenSharing.sh)"
-```
+- **Direct Download**: Downloads the Google Drive disk image directly from Google's official source
+- **DMG/PKG Handling**: Mounts the DMG and installs whether the payload is a `.app` bundle or a `.pkg` installer
+- **Auto-Update Detection**: Skips installation if Google Drive is already installed (Google Drive handles its own updates)
+- **Process Management**: Can terminate a running Google Drive instance during installation
+- **Comprehensive Logging**: Detailed logs for troubleshooting
+
+## Requirements
+
+- macOS 10.13 or later
+- Administrative privileges
+- Internet connectivity to download the Google Drive package
+
+## Configuration Variables
+
+The script uses several key variables that can be customized if needed:
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+| `weburl` | https://dl.google.com/drive-file-stream/GoogleDrive.dmg | Direct download URL for the Google Drive disk image |
+| `appname` | Google Drive | Display name used in logs |
+| `app` | Google Drive.app | Folder of the application as installed |
+| `logandmetadir` | /Library/Logs/Microsoft/IntuneScripts/GoogleDrive | Directory where logs and the meta file are stored |
+| `processpath` | /Applications/Google Drive.app/Contents/MacOS/Google Drive | Full path to the Google Drive process |
+| `terminateprocess` | true | Whether to terminate Google Drive if running during installation |
+| `autoUpdate` | true | Whether to skip installation if Google Drive is already installed |
 
 ## Script Settings
 
@@ -17,13 +39,6 @@ sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/microsoft/shel
 
 ## Log File
 
-The log file will output to ***/Library/Logs/Microsoft/IntuneScripts/EnableScreenSharing/EnableScreenSharing.log*** by default. Exit status is either 0 or 1. To gather this log with Intune remotely take a look at  [Troubleshoot macOS shell script policies using log collection](https://docs.microsoft.com/en-us/mem/intune/apps/macos-shell-scripts#troubleshoot-macos-shell-script-policies-using-log-collection)
+The log file outputs to ***/Library/Logs/Microsoft/IntuneScripts/GoogleDrive/Google Drive.log*** by default. Exit status is either 0 or 1.
 
-```
-##############################################################
-# Fri 26 Nov 2021 12:57:06 GMT | Logging configuration of [EnableScreenSharing] to [/Library/Logs/Microsoft/IntuneScripts/EnableScreenSharing/EnableScreenSharing.log]
-############################################################
-
-Fri 26 Nov 2021 12:57:06 GMT | Writing to /var/db/launchd.db/com.apple.launchd/overrides.plist
-Fri 26 Nov 2021 12:57:06 GMT | Launching com.apple.screensharing Launch Daemon
-```
+To gather this log with Intune remotely, see [Troubleshoot macOS shell script policies using log collection](https://docs.microsoft.com/en-us/mem/intune/apps/macos-shell-scripts#troubleshoot-macos-shell-script-policies-using-log-collection).

--- a/macOS/Config/Enable OneDrive Finder Sync/EnableOneDriveFinderSync.sh
+++ b/macOS/Config/Enable OneDrive Finder Sync/EnableOneDriveFinderSync.sh
@@ -2,7 +2,23 @@
 #set -x
 ############################################################################################
 ##
-## Script to enable the Finder Extension for OneDrive
+## Script to enable the Finder Sync extension for OneDrive
+##
+## Recommended Intune settings:
+##   - Run script as signed-in user : No   (script handles user-context invocation itself)
+##   - Hide script notifications on devices : Yes
+##   - Script frequency : Not configured
+##   - Number of times to retry if script fails : 3
+##
+## Notes:
+##   When this script is run from an MDM / launchd context (e.g. by the Intune agent),
+##   pluginkit invoked directly will return:
+##       "match: connection invalid"
+##   ...because the process is not attached to the user's Aqua GUI launchd bootstrap.
+##   The fix is to re-enter the user's session with `launchctl asuser <uid>` so that
+##   pluginkit can talk to the per-user pluginkit / extensionkit endpoints.
+##   See: https://github.com/microsoft/shell-intune-samples/issues/137
+##        https://github.com/microsoft/shell-intune-samples/issues/148
 ##
 ############################################################################################
 
@@ -17,69 +33,100 @@
 ## Feedback: neiljohn@microsoft.com
 
 appname="EnableOneDriveFinderSync"
-logandmetadir="$HOME/Library/Logs/Microsoft/IntuneScripts/$appname"
-log="$logandmetadir/$appname.log"
 application="/Applications/OneDrive.app"
 
-
-# Check if the log directory has been created
-if [ -d $logandmetadir ]; then
-    # Already created
-    echo "$(date) | Log directory already exists - $logandmetadir"
-else
-    # Creating Metadirectory
-    echo "$(date) | creating log directory - $logandmetadir"
-    mkdir -p $logandmetadir
+# Identify the active console user (works regardless of whether this script is
+# invoked as root by the Intune agent or as the signed-in user).
+currentUser=$(/usr/bin/stat -f%Su /dev/console)
+if [[ -z "$currentUser" || "$currentUser" == "root" || "$currentUser" == "_mbsetupuser" || "$currentUser" == "loginwindow" ]]; then
+    echo "$(date) | No real console user logged in (got '$currentUser'); nothing to do."
+    exit 0
 fi
+uid=$(/usr/bin/id -u "$currentUser")
 
+# Log to the user's home so existing collection paths still work.
+userHome=$(/usr/bin/dscl . -read "/Users/$currentUser" NFSHomeDirectory 2>/dev/null | awk -F': ' '/NFSHomeDirectory/ {print $2}')
+[[ -z "$userHome" ]] && userHome="/Users/$currentUser"
+logandmetadir="$userHome/Library/Logs/Microsoft/IntuneScripts/$appname"
+log="$logandmetadir/$appname.log"
+
+# Make sure the log directory exists and is owned by the user.
+if [[ ! -d "$logandmetadir" ]]; then
+    mkdir -p "$logandmetadir"
+    chown -R "$currentUser":staff "$logandmetadir" 2>/dev/null
+fi
 
 # Start logging
 exec &> >(tee -a "$log")
 
-# Begin Script Body
 echo ""
 echo "##############################################################"
-echo "# $(date) | Starting running of script $appname"
-echo "############################################################"
-echo ""
+echo "# $(date) | Starting $appname"
+echo "##############################################################"
+echo "$(date) | Console user : $currentUser ($uid)"
+echo "$(date) | Running as   : $(/usr/bin/id -un) ($(/usr/bin/id -u))"
 
-echo "$(date) | OneDrive config: Looking for required applications... "
+# Helper: run a command inside the console user's GUI launchd session so that
+# pluginkit attaches to the per-user pluginkit endpoints.
+runAsUser() {
+    /bin/launchctl asuser "$uid" /usr/bin/sudo -u "$currentUser" "$@"
+}
 
-# Wait for OneDrive to be installed
-while [[ $ready -ne 1 ]];do
-
-    if [[ -a "$application" ]]; then
-        ready=1
-        echo "$(date) | $application found!"
-    else
-        echo "$(date) | OneDrive config: $i not installed yet"  
-        echo "$(date) | OneDrive config: Waiting for 60 seconds" 
-        sleep 60
-    fi
-
+# Wait for OneDrive to be installed (cap the wait so the agent doesn't hang forever)
+attempts=0
+while [[ ! -d "$application" && $attempts -lt 30 ]]; do
+    echo "$(date) | $application not installed yet, waiting 60s (attempt $((attempts+1))/30)"
+    sleep 60
+    attempts=$((attempts+1))
 done
 
-# Get Extension Name (differs between standalone and VPP version)
-echo "$(date) | Finding installed OneDrive type (VPP or standalone)" 
-if pluginkit -m | grep "com.microsoft.OneDrive-mac.FinderSync"; then
-    echo "$(date) | OneDrive installed via VPP. Extension name is com.microsoft.OneDrive-mac.FinderSync" 
-    extensionname="com.microsoft.OneDrive-mac.FinderSync"
+if [[ ! -d "$application" ]]; then
+    echo "$(date) | OneDrive still not installed after waiting; exiting."
+    exit 1
 fi
+echo "$(date) | $application found"
 
-if pluginkit -m | grep "com.microsoft.OneDrive.FinderSync"; then
-    echo "$(date) | OneDrive installed standalone. Extension name is com.microsoft.OneDrive.FinderSync" 
+# Discover the installed extension ID (differs between standalone and VPP/Mac App Store).
+echo "$(date) | Looking for an installed OneDrive Finder Sync extension"
+matchOutput=$(runAsUser /usr/bin/pluginkit -m -i com.microsoft.OneDrive.FinderSync 2>/dev/null)
+if [[ -n "$matchOutput" ]]; then
     extensionname="com.microsoft.OneDrive.FinderSync"
+    echo "$(date) | Found standalone extension: $extensionname"
+else
+    matchOutput=$(runAsUser /usr/bin/pluginkit -m -i com.microsoft.OneDrive-mac.FinderSync 2>/dev/null)
+    if [[ -n "$matchOutput" ]]; then
+        extensionname="com.microsoft.OneDrive-mac.FinderSync"
+        echo "$(date) | Found VPP / Mac App Store extension: $extensionname"
+    fi
 fi
 
-# Check if the extension is already enabled and enable it
-echo "$(date) | Checking extension status" 
-if pluginkit -m | grep "+    $extensionname"; then
-    echo "$(date) | OneDrive FinderSync already enabled" 
+if [[ -z "${extensionname:-}" ]]; then
+    echo "$(date) | No OneDrive Finder Sync extension registered yet; exiting so the script can retry on the next run."
+    exit 1
+fi
+
+# Already enabled?
+status=$(runAsUser /usr/bin/pluginkit -m -i "$extensionname" 2>/dev/null)
+echo "$(date) | Current status: ${status:-<empty>}"
+if [[ "$status" == +* ]]; then
+    echo "$(date) | $extensionname is already enabled; nothing to do."
+    exit 0
+fi
+
+# Enable the extension inside the user's GUI session so we don't get
+# "match: connection invalid".
+echo "$(date) | Enabling $extensionname for $currentUser"
+runAsUser /usr/bin/pluginkit -e use -i "$extensionname"
+rc=$?
+
+# Verify
+status=$(runAsUser /usr/bin/pluginkit -m -i "$extensionname" 2>/dev/null)
+echo "$(date) | Post-enable status: ${status:-<empty>}"
+
+if [[ $rc -eq 0 && "$status" == +* ]]; then
+    echo "$(date) | $appname completed successfully"
+    exit 0
 else
-    echo "$(date) | OneDrive config: Enabling FinderSync" 
-    echo "$(date) | running pluginkit -e use -i $extensionname"
-
-    pluginkit -e use -i $extensionname
-
-    echo "$(date) | Script finished"
+    echo "$(date) | $appname failed to enable extension (rc=$rc)"
+    exit 1
 fi

--- a/macOS/Config/Enable OneDrive Finder Sync/README.md
+++ b/macOS/Config/Enable OneDrive Finder Sync/README.md
@@ -12,15 +12,17 @@ The extension ID of the OneDrive client is different for the standalone version 
 
 ## Script Settings
 
-- Run script as signed-in user : **Yes**
+- Run script as signed-in user : **No**
 - Hide script notifications on devices : Yes
-- Script frequency : 
+- Script frequency :
   - **Not configured** (which will cause the script to run once)
 - Number of times to retry if script fails : 3
 
+> **Why "No"?** When the Intune agent runs `pluginkit` directly in its own launchd context (whether as root or even as the signed-in user) it can fail with `match: connection invalid` because it is not attached to the user's Aqua GUI session. The script now runs as root and re-enters the console user's GUI launchd session via `launchctl asuser <uid>` so that `pluginkit` can talk to the per-user pluginkit endpoints. Resolves [#137](https://github.com/microsoft/shell-intune-samples/issues/137) and [#148](https://github.com/microsoft/shell-intune-samples/issues/148).
+
 ## Log File
 
-The log file will output to **~/Library/Logs/Microsoft/IntuneScripts/EnableOneDriveFinderSync/EnableOneDriveFinderSync.log** by default. Exit status is either 0 or 1. To gather this log with Intune remotely take a look at [Troubleshoot macOS shell script policies using log collection](https://docs.microsoft.com/en-us/mem/intune/apps/macos-shell-scripts#troubleshoot-macos-shell-script-policies-using-log-collection).
+The log file will output to **~/Library/Logs/Microsoft/IntuneScripts/EnableOneDriveFinderSync/EnableOneDriveFinderSync.log** (where `~` is the console user's home) by default. Exit status is either 0 or 1. To gather this log with Intune remotely take a look at [Troubleshoot macOS shell script policies using log collection](https://docs.microsoft.com/en-us/mem/intune/apps/macos-shell-scripts#troubleshoot-macos-shell-script-policies-using-log-collection).
 ```
 ##############################################################
 # Fri Jan  8 14:21:01 AEST 2021 | Starting config of EnableOneDriveFinderSync

--- a/macOS/Config/Manage Accounts/downgradeUsertoStandard.sh
+++ b/macOS/Config/Manage Accounts/downgradeUsertoStandard.sh
@@ -28,8 +28,9 @@
 
 scriptname="Downgrade Admin Users to Standard"
 log="/var/log/downgradeadminusers.log"
-abmcheck=true   # Only downgrade users if this device is ABM managed
-downgrade=true  # If set to false, script will not do anything
+abmcheck=true                # Only downgrade users if this device is ABM managed
+downgrade=true               # If set to false, script will not do anything
+adminaccountname="admin"     # Account name to leave as Admin (will not be downgraded)
 logandmetadir="/Library/Logs/Microsoft/IntuneScripts/downgradeAdminUsers"
 log="$logandmetadir/downgradeAdminUsers.log"
 
@@ -64,27 +65,29 @@ echo "# $(date) | Starting $scriptname"
 echo "############################################################"
 echo ""
 
+# Honour the downgrade=false kill switch up front so the ABM check below
+# can never re-enable downgrading against the user's wishes.
+if [[ "$downgrade" != true ]]; then
+  echo "downgrade is set to [$downgrade]; nothing to do, exiting."
+  exit 0
+fi
+
 # Is this a ABM DEP device?
 if [[ "$abmcheck" = true ]]; then
-  downgrade=false
   echo "Checking MDM Profile Type"
-  profiles status -type enrollment | grep "Enrolled via DEP: Yes"
-  if [[ ! $? == 0 ]]; then
+  if ! profiles status -type enrollment | grep -q "Enrolled via DEP: Yes"; then
     echo "This device is not ABM managed"
-    exit 0;
+    exit 0
   else
     echo "Device is ABM Managed"
-    downgrade=true
   fi
 fi
 
-if [[ $downgrade = true ]]; then
-  while read useraccount; do
-    if [[ "$useraccount" == "admin" ]]; then
-        echo "Leaving admin account as Admin"
-    else
-        echo "Making $useraccount a normal user"
-        #/usr/sbin/dseditgroup -o edit -d $useraccount -t user admin
-    fi
-  done < <(dscl . list /Users UniqueID | awk '$2 >= 501 {print $1}')
-fi
+while read useraccount; do
+  if [[ "$useraccount" == "$adminaccountname" ]]; then
+      echo "Leaving [$adminaccountname] account as Admin"
+  else
+      echo "Making $useraccount a normal user"
+      #/usr/sbin/dseditgroup -o edit -d $useraccount -t user admin
+  fi
+done < <(dscl . list /Users UniqueID | awk '$2 >= 501 {print $1}')

--- a/macOS/Tools/Migration/intuneMigrationSample.sh
+++ b/macOS/Tools/Migration/intuneMigrationSample.sh
@@ -33,8 +33,22 @@
 
 # Replace these with your Jamf Pro details
 JAMF_PRO_URL="https://yourenvironment.jamfcloud.com"  # URL of your Jamf Pro server
-USERNAME="migration_account"                          # This should be a Jamf Pro user with the Jamf Pro Server Action 'Send Computer Unmanage Command' enabled and Jamf Pro Server Objects 'Computers' Read.
+
+# Auth method: "basic" (legacy Jamf Pro user account) or "oauth" (Jamf Pro 10.49+ API
+# Roles & Clients, recommended). When using "oauth" the role must be granted at minimum:
+#   - Jamf Pro Server Action: 'Send Computer Unmanage Command'
+#   - Jamf Pro Server Object: 'Read Computers'
+# See: https://learn.jamf.com/bundle/jamf-pro-documentation-current/page/API_Roles_and_Clients.html
+JAMF_AUTH_METHOD="basic"
+
+# --- Used when JAMF_AUTH_METHOD="basic" ------------------------------------------------
+USERNAME="migration_account"                          # Jamf Pro user with the same role/permissions as listed above
 PASSWORD="migration_account_password"                 # Password for the above user
+
+# --- Used when JAMF_AUTH_METHOD="oauth" ------------------------------------------------
+JAMF_CLIENT_ID=""                                     # Client ID of the Jamf Pro API Client
+JAMF_CLIENT_SECRET=""                                 # Client secret of the Jamf Pro API Client
+
 LOG="/Library/Logs/Microsoft/IntuneScripts/intuneMigration/intuneMigration.log"
 JAMF_API_VERSION="new"     # Set to "classic" for (JSSResource) or new for (api) to use the classic or new API
 REMOVE_WORKPLACE_JOIN_CERTS=true  # Remove Entra WorkplaceJoin (MS-Organization-Access) certs from login keychain before enrollment
@@ -369,10 +383,61 @@ get_serial_number() {
   system_profiler SPHardwareDataType | awk '/Serial Number/ {print $4}'
 }
 
-# Function to obtain an authentication token
+# Function to obtain an authentication token.
+#
+# Honours JAMF_AUTH_METHOD:
+#   - "basic": legacy Jamf Pro user account against /api/v1/auth/token
+#   - "oauth": Jamf Pro 10.49+ API Client (client_credentials) against /api/oauth/token
+#
+# Returns the bearer token on stdout, or empty string on failure.
 get_auth_token() {
-  auth_token=$(curl -su "$USERNAME:$PASSWORD" -X POST "$JAMF_PRO_URL/api/v1/auth/token" | jq -r '.token')
-  echo "$auth_token"
+  local token=""
+  local response=""
+  local http_code=""
+
+  case "${JAMF_AUTH_METHOD:-basic}" in
+    oauth)
+      if [[ -z "$JAMF_CLIENT_ID" || -z "$JAMF_CLIENT_SECRET" ]]; then
+        echo "ERROR: JAMF_AUTH_METHOD=oauth but JAMF_CLIENT_ID and/or JAMF_CLIENT_SECRET are empty." >&2
+        echo ""
+        return 1
+      fi
+      response=$(curl -s -w '\n%{http_code}' \
+        -X POST "$JAMF_PRO_URL/api/oauth/token" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        --data-urlencode "client_id=$JAMF_CLIENT_ID" \
+        --data-urlencode "grant_type=client_credentials" \
+        --data-urlencode "client_secret=$JAMF_CLIENT_SECRET")
+      http_code=$(echo "$response" | tail -n1)
+      response=$(echo "$response" | sed '$d')
+      token=$(echo "$response" | jq -r '.access_token // empty' 2>/dev/null)
+      ;;
+    basic|"")
+      if [[ -z "$USERNAME" || -z "$PASSWORD" ]]; then
+        echo "ERROR: JAMF_AUTH_METHOD=basic but USERNAME and/or PASSWORD are empty." >&2
+        echo ""
+        return 1
+      fi
+      response=$(curl -s -w '\n%{http_code}' -u "$USERNAME:$PASSWORD" \
+        -X POST "$JAMF_PRO_URL/api/v1/auth/token")
+      http_code=$(echo "$response" | tail -n1)
+      response=$(echo "$response" | sed '$d')
+      token=$(echo "$response" | jq -r '.token // empty' 2>/dev/null)
+      ;;
+    *)
+      echo "ERROR: Invalid JAMF_AUTH_METHOD '$JAMF_AUTH_METHOD' (expected 'basic' or 'oauth')." >&2
+      echo ""
+      return 1
+      ;;
+  esac
+
+  if [[ -z "$token" || "$token" == "null" ]]; then
+    echo "ERROR: Failed to obtain Jamf Pro auth token (HTTP $http_code, method=$JAMF_AUTH_METHOD). Response: $response" >&2
+    echo ""
+    return 1
+  fi
+
+  echo "$token"
 }
 
 # Function to get the computer_id from Jamf Pro based on serial number
@@ -523,7 +588,11 @@ start_progress_dialog
 serial_number=$(get_serial_number)
 echo "Serial Number: $serial_number"
 auth_token=$(get_auth_token)
-echo "Auth Token: $auth_token"
+if [[ -z "$auth_token" ]]; then
+    echo "Aborting migration: could not obtain a Jamf Pro auth token. Check JAMF_AUTH_METHOD and credentials." >&2
+    exit 1
+fi
+echo "Auth Token: obtained (length=${#auth_token})"
 computer_id=$(get_computer_id "$serial_number" "$auth_token")
 echo "Computer ID: $computer_id"
 

--- a/macOS/Tools/Migration/readme.md
+++ b/macOS/Tools/Migration/readme.md
@@ -75,11 +75,19 @@ https://github.com/user-attachments/assets/5669bd8d-7642-4321-bc46-cd38b97e28a6
 
 ## Configuration Options
 
-- **Jamf Pro Credentials**  
-  - Inside the script, you can edit your `USERNAME`, `PASSWORD`, and `JAMF_PRO_URL` to point to the correct Jamf Pro instance.  
-- **Script Functions**  
+- **Jamf Pro Authentication** (set `JAMF_AUTH_METHOD` at the top of the script)
+  - `basic` (default, legacy) — uses `USERNAME` / `PASSWORD` for a Jamf Pro **user account** against `/api/v1/auth/token`. Still works on every supported Jamf Pro version.
+  - `oauth` (recommended on Jamf Pro **10.49+**) — uses `JAMF_CLIENT_ID` / `JAMF_CLIENT_SECRET` for an [API Roles & Clients](https://learn.jamf.com/bundle/jamf-pro-documentation-current/page/API_Roles_and_Clients.html) credential against `/api/oauth/token`. This is the only path that works for tenants which have disabled basic-auth user tokens.
+
+  The Jamf Pro role (whether assigned to a user account or an API Client) needs at minimum:
+  - **Jamf Pro Server Action**: `Send Computer Unmanage Command`
+  - **Jamf Pro Server Object**: `Read Computers`
+
+- **Jamf Pro URL**
+  - Set `JAMF_PRO_URL` to your Jamf Pro server (e.g. `https://yourenvironment.jamfcloud.com`).
+- **Script Functions**
   - The script is modularized into functions (e.g., `check_if_managed`, `remove_jamf_framework`, etc.), which you can rearrange or customize for your environment.
-- **REMOVE_WORKPLACE_JOIN_CERTS**  
+- **REMOVE_WORKPLACE_JOIN_CERTS**
   - When set to `true` (the default), the script automatically removes Entra WorkplaceJoin (`MS-Organization-Access`) certificates from the logged-in user's login keychain before enrollment. These certificates are created when a device was registered in Entra ID for compliance (e.g., while managed by Jamf with Intune device compliance) and can block fresh Intune enrollment if not removed. Set to `false` if your environment does not use Entra device registration alongside Jamf. A standalone version of this logic is available in `removeWorkplaceJoinCerts.sh` for manual diagnostics.
 
 ---


### PR DESCRIPTION
Batch fixes for several open issues:

### Resolves

- **#167** — `macOS/Apps/Google Drive/readme.md` — Rewrites the readme so it actually describes the Google Drive installer (was the unrelated screen-sharing readme).
- **#139** — `macOS/Config/Manage Accounts/downgradeUsertoStandard.sh` — Honour `downgrade=false` up front so the ABM check can no longer re-enable downgrading against the user's wishes.
- **#140** — Same script — Add `adminaccountname` variable so the protected admin account is no longer hard-coded to the literal string `admin`.
- **#148** — `macOS/Config/Enable OneDrive Finder Sync/EnableOneDriveFinderSync.sh` — When the Intune agent invokes `pluginkit` directly it isn't attached to the user's Aqua GUI launchd session, so `pluginkit` returns `match: connection invalid` and the extension is never enabled. Rewrites the script to run as root, detect the active console user, and re-enter the user's GUI session via `launchctl asuser <uid>` for every `pluginkit` call. Also updates the readme (Intune setting changes from "Run as signed-in user: Yes" to "No").
- **#201** — `macOS/Tools/Migration/intuneMigrationSample.sh` — Adds Jamf Pro **API Client (OAuth)** auth alongside the existing basic auth path. Jamf Pro 10.49+ tenants using API Roles & Clients were getting silent empty tokens followed by HTTP 401 on every call. New `JAMF_AUTH_METHOD=basic|oauth` switch with `JAMF_CLIENT_ID` / `JAMF_CLIENT_SECRET`, fail-fast token validation, and stops logging the bearer token verbatim. Readme documents both methods and the minimum Jamf role permissions required.

### Testing

- All scripts re-checked with `bash -n` and `zsh -n`.
- Citrix download regression separately verified live (#160) and closed.
- OneDrive `launchctl asuser` pattern matches the working community fix from #137.
