### PR TITLE
Fix Swift Dialog (PKG) onboarding to be idempotent (#245)

### DIFF
--- a/macOS/Config/Swift Dialog (PKG)/IntuneScripts/intunePost.sh
+++ b/macOS/Config/Swift Dialog (PKG)/IntuneScripts/intunePost.sh
@@ -17,11 +17,13 @@ PKG_URL="https://github.com/swiftDialog/swiftDialog/releases/download/v2.5.2/dia
 mkdir -p "$logDir"
 exec > >(tee -a "$logDir/postinstall.log") 2>&1
 
-# Check if we've run before
-#if [[ -f "$logDir/onboardingComplete" ]]; then
-#  echo "$(date) | POST | We've already completed onboarding, let's exit quietly"
-#  exit 1
-#fi
+# Skip if onboarding has already completed on this device.
+# Belt-and-braces with the matching check in intunePre.sh: a customer can
+# pre-create this file to opt a device out of onboarding entirely.
+if [[ -f "$logDir/onboardingComplete" ]]; then
+    echo "$(date) | POST | Onboarding already completed (marker: $logDir/onboardingComplete); exiting quietly."
+    exit 0
+fi
 
 # Check if SwiftDialog is installed
 if [[ ! -f "$DIALOG_BIN" ]]; then

--- a/macOS/Config/Swift Dialog (PKG)/IntuneScripts/intunePre.sh
+++ b/macOS/Config/Swift Dialog (PKG)/IntuneScripts/intunePre.sh
@@ -18,6 +18,16 @@ PKG_URL="https://github.com/swiftDialog/swiftDialog/releases/download/v2.5.2/dia
 mkdir -p "$logDir"
 exec > >(tee -a "$logDir/preinstall.log") 2>&1
 
+# Skip if onboarding has already completed on this device.
+# Exiting non-zero from a pre-install script aborts the whole PKG install
+# (https://learn.microsoft.com/intune/intune-service/apps/macos-unmanaged-pkg),
+# which means we won't wipe the existing swiftDialog install or run the post
+# script again. Pre-create this file to opt a device out of onboarding entirely.
+if [[ -f "$logDir/onboardingComplete" ]]; then
+    echo "$(date) | PRE | Onboarding already completed (marker: $logDir/onboardingComplete); skipping install."
+    exit 1
+fi
+
 if [ -e "/Library/Application Support/Dialog" ]; then
     echo "$(date) | PRE | Removing previous installation"
     rm -rf "/Library/Application Support/Dialog"

--- a/macOS/Config/Swift Dialog (PKG)/readme.md
+++ b/macOS/Config/Swift Dialog (PKG)/readme.md
@@ -79,6 +79,32 @@ There are three areas to consider when customising the package
 2. **Icons**: It's important that any icons you reference are available, they can either be included in the package or you can define web URLs.
 3. **Scripts**: Any scripts that you put in the scripts folder will be executed in alphanumeric order. Some samples are provided here, but remove what you don't need they are provide to show whats possible.
 
+## Run-once / opt-out marker
+
+The pre- and post-install scripts only run onboarding the **first** time. After a successful run, `intunePost.sh` writes a marker file:
+
+```
+/Library/Application Support/Microsoft/IntuneScripts/Swift Dialog/onboardingComplete
+```
+
+On any subsequent install attempt:
+
+- `intunePre.sh` sees the marker and **exits 1**, which (per [Microsoft Learn](https://learn.microsoft.com/en-us/intune/intune-service/apps/macos-unmanaged-pkg)) aborts the whole PKG install — so swiftDialog is not re-deployed and onboarding is not re-shown.
+- `intunePost.sh` performs the same check as a belt-and-braces guard and exits 0.
+
+To **opt a device out of onboarding entirely** (e.g. for a device that has already been onboarded by another mechanism), pre-create the marker before assigning the app:
+
+```bash
+sudo mkdir -p "/Library/Application Support/Microsoft/IntuneScripts/Swift Dialog"
+sudo touch "/Library/Application Support/Microsoft/IntuneScripts/Swift Dialog/onboardingComplete"
+```
+
+To **force a re-onboarding** on a device, simply delete the marker:
+
+```bash
+sudo rm "/Library/Application Support/Microsoft/IntuneScripts/Swift Dialog/onboardingComplete"
+```
+
 # Deploying via Intune
 
 Once you have your customised PKG ready, you should test it first and then we can upload to Intune for deployment.


### PR DESCRIPTION
Resolves #245.

Thanks to @threeonparfive for the very detailed bug report — they were correct on every count.

## Problem

The Swift Dialog (PKG) onboarding wrapper was supposed to run only once per device, but in practice it re-ran whenever Intune re-evaluated the PKG:

- `intunePost.sh` had a marker check, but it was **commented out**.
- `intunePre.sh` had **no marker check at all**, so its destructive cleanup (`rm -rf` of the existing swiftDialog install, log dir wipe, etc.) always ran.
- Pre-creating the marker file was therefore a no-op, even though the README implied it should opt a device out.

## Fix

- **`intunePre.sh`**: added a marker check at the top, *before* any cleanup. If `onboardingComplete` exists the script `exit 1`s, which (per [Microsoft Learn](https://learn.microsoft.com/intune/intune-service/apps/macos-unmanaged-pkg)) aborts the entire PKG install and skips post — making the marker a genuine opt-out switch.
- **`intunePost.sh`**: uncommented the equivalent guard as belt-and-braces (changed its `exit 1` to `exit 0` since by post-install stage there's nothing to abort). Marker is still written at the end of a successful run.
- **`readme.md`**: new "Run-once / opt-out marker" section documenting the marker path, how to pre-create it to opt a device out, and how to delete it to force re-onboarding.

## Marker path

`/Library/Application Support/Microsoft/IntuneScripts/Swift Dialog/onboardingComplete`
