### PR TITLE
Require root for onboardingProcess.zsh + document in readme (#149)

### DIFF
--- a/macOS/Config/Swift Dialog/onboardingProcess.zsh
+++ b/macOS/Config/Swift Dialog/onboardingProcess.zsh
@@ -27,6 +27,21 @@ logandmetadir="/Library/Application Support/Microsoft/IntuneScripts/$appname"   
 enrollmentWindowHours=1                                                         # The number of hours after enrollment that the script should run
 checkEnrollmentTime=true                                                        # Should we check the enrollment time? (Do NOT set this to false in production!!)
 
+# This script must run as root. When deployed via the Intune shell-script
+# channel that happens automatically; if you're testing locally you need to
+# invoke it with sudo. Without root we cannot write to
+# /Library/Application Support/Microsoft/IntuneScripts and the user hits
+# 'No such file or directory' / 'Permission denied' on the move steps later.
+if [[ $(id -u) -ne 0 ]]; then
+    echo "$(date) | ERROR: onboardingProcess.zsh must be run as root (uid 0)."
+    echo "$(date) |        When deployed via Intune the shell-script agent runs this as root"
+    echo "$(date) |        automatically. If you're testing on a device, run:"
+    echo "$(date) |            sudo ./onboardingProcess.zsh"
+    echo "$(date) |        Also confirm in the Intune portal that the script is configured with"
+    echo "$(date) |        'Run script as signed-in user: No'."
+    exit 1
+fi
+
 # Generated variables
 tempdir=$(mktemp -d)
 log="$logandmetadir/$appname.log"                                               # The location of the script log file

--- a/macOS/Config/Swift Dialog/readme.md
+++ b/macOS/Config/Swift Dialog/readme.md
@@ -98,3 +98,11 @@ Once you have an internet facing URL for the zip file, edit the **onboardingProc
 Note: if you're editing on Windows make sure to save the onboardingProcess.zsh as **Unix (LF)** format otherwise the script will not run and will receive a permission denied which may be found in the log file on the Mac under: /Library/Application Support/Microsoft/IntuneScripts/Swift Dialog/
 
 Once done, you can upload and assign the onboardingProcess.zsh script via Intune to macOS devices.
+
+When configuring the script in Intune, make sure that **Run script as signed-in user** is set to **No**. The script writes to `/Library/Application Support/Microsoft/IntuneScripts/` and downloads / unzips the onboarding payload there, so it must run as root. The script now refuses to run as a non-root user and will exit with an explanatory error in the log if it is launched any other way (for example by double-clicking it in Finder, or by running it manually without `sudo`).
+
+If you want to test the script on a device before deploying it through Intune, run it from Terminal with:
+
+```bash
+sudo /path/to/onboardingProcess.zsh
+```


### PR DESCRIPTION
Resolves #149.

Multiple users (#149 reporter @ashorinx13 and @Expo08 in comments) reported `No such file or directory` / `Permission denied` errors when running `onboardingProcess.zsh` manually. Root cause: the script writes to `/Library/Application Support/Microsoft/IntuneScripts/`, which only root can do, but there was no upfront check — so it ran a long way before the move/unzip steps blew up confusingly.

## Fix

- **`onboardingProcess.zsh`**: explicit `id -u` check at the top. If we're not root, log a clear message explaining (a) Intune runs this as root automatically when **Run script as signed-in user = No**, and (b) local testing needs `sudo`. Exit non-zero so Intune surfaces the failure rather than leaving the device half-onboarded.
- **`readme.md`**: documents the Intune setting and the `sudo` invocation for local testing.
