### PR TITLE
Secure /Users/Shared too in SecureUsersHomeFolders.zsh (#203)

### DIFF
--- a/macOS/Config/Secure User's Home Folders/README.md
+++ b/macOS/Config/Secure User's Home Folders/README.md
@@ -3,6 +3,15 @@ This Custom Script is required when implementing following CIS or NIST Recommend
 - **CIS**: Ensure Home Folders Are Secure (Automated)
 - **NIST**: Secure User's Home Folders
 
+## What it does
+
+The script remediates two things that Microsoft Defender / Secure Score and the CIS macOS benchmark expect to see:
+
+1. Every user home folder under `/Users` (excluding `Shared`, `Guest` and `.localized`) is set to mode `700`, `711` or `750`. The script removes group / other read, write and execute on any folder that does not already match.
+2. `/Users/Shared` is set to mode `1777` (sticky bit, world-writable) and owned by `root:wheel`. This was missing from earlier versions of the script and is the most common reason that devices continued to be flagged as vulnerable in Defender even after the script ran successfully — see [this Tech Community thread](https://techcommunity.microsoft.com/discussions/microsoft-security/secure-score---secure-home-folders-in-macos/3930746).
+
+The script must run as `root` and now exits non-zero if any folder could not be remediated, so failures surface in Intune instead of being silently logged.
+
 ## Script Settings
 
 - Run script as signed-in user : No
@@ -16,8 +25,13 @@ The log file will output to ***/Library/Logs/Microsoft/IntuneScripts/SecureUsers
 
 ```
 ##############################################################
-# Fri Nov 29 09:11:27 EET 2023 | Starting running of script SecureUsersHomeFolders
+# Fri Apr 24 09:11:27 BST 2026 | Starting running of script SecureUsersHomeFolders
 ############################################################
 
-Fri Nov 29 09:11:27 EET 2023 | User's Home Folders are now secured or already secured. Closing script...
+Fri Apr 24 09:11:27 BST 2026 | OK    | /Users/alice already mode 700
+Fri Apr 24 09:11:27 BST 2026 | FIX   | /Users/bob is mode 755, removing group/other rwx
+Fri Apr 24 09:11:27 BST 2026 | OK    | /Users/bob is now mode 700
+Fri Apr 24 09:11:27 BST 2026 | FIX   | /Users/Shared is mode 777 owner root:wheel, resetting to 1777 root:wheel
+Fri Apr 24 09:11:27 BST 2026 | OK    | /Users/Shared is now mode 1777 root:wheel
+Fri Apr 24 09:11:27 BST 2026 | All user home folders and /Users/Shared are secured. Exiting 0.
 ```

--- a/macOS/Config/Secure User's Home Folders/SecureUsersHomeFolders.zsh
+++ b/macOS/Config/Secure User's Home Folders/SecureUsersHomeFolders.zsh
@@ -21,6 +21,13 @@ appname="SecureUsersHomeFolders"
 logandmetadir="/Library/Logs/Microsoft/IntuneScripts/$appname"
 log="$logandmetadir/$appname.log"
 
+# Track failures so we can exit non-zero if anything could not be remediated.
+# Microsoft Defender / Secure Score will only mark the device as compliant
+# once every user home folder is mode 700/711/750 AND /Users/Shared is 1777
+# with sticky bit set. See:
+#   https://techcommunity.microsoft.com/discussions/microsoft-security/secure-score---secure-home-folders-in-macos/3930746
+failures=0
+
 # Check if the log directory has been created
 if [ -d $logandmetadir ]; then
     # Already created
@@ -31,14 +38,83 @@ else
     mkdir -p $logandmetadir
 fi
 
-# Secure User's Home Folders
+# Must run as root - we're chmod'ing other users' home directories.
+if [[ $(id -u) -ne 0 ]]; then
+    echo "$(date) | ERROR: $appname must be run as root (uid 0). Exiting."
+    exit 1
+fi
+
+# Secure each user home folder under /Users.
+#
+# /Users is firmlinked to /System/Volumes/Data/Users on modern macOS, so the
+# inodes (and therefore the permissions we set here) are shared. We use the
+# /Users path because that is what the Defender for Endpoint posture check
+# evaluates.
+#
+# Acceptable end-state per the CIS macOS benchmark "Ensure Home Folders Are
+# Secure": mode 700, 711 or 750. /Users/Shared and Guest are excluded here
+# and handled separately below.
 SecureUsersHomeFolders() {
-  IFS=$'\n'
-  for userDirs in $( /usr/bin/find /System/Volumes/Data/Users -mindepth 1 -maxdepth 1 -type d ! \( -perm 700 -o -perm 711 \) | /usr/bin/grep -v "Shared" | /usr/bin/grep -v "Guest" ); do
-    /bin/chmod og-rwx "$userDirs"
-  done
-  unset IFS
-echo  "$(date) | User's Home Folders are now secured or already secured. Closing script..."
+  local userDir mode
+  while IFS= read -r userDir; do
+    [[ -z "$userDir" ]] && continue
+    mode=$(/usr/bin/stat -f "%Lp" "$userDir")
+    case "$mode" in
+      700|711|750)
+        echo "$(date) | OK    | $userDir already mode $mode"
+        ;;
+      *)
+        echo "$(date) | FIX   | $userDir is mode $mode, removing group/other rwx"
+        if ! /bin/chmod og-rwx "$userDir"; then
+          echo "$(date) | ERROR | chmod failed on $userDir"
+          failures=$((failures + 1))
+          continue
+        fi
+        mode=$(/usr/bin/stat -f "%Lp" "$userDir")
+        case "$mode" in
+          700|711|750)
+            echo "$(date) | OK    | $userDir is now mode $mode"
+            ;;
+          *)
+            echo "$(date) | ERROR | $userDir is still mode $mode after chmod"
+            failures=$((failures + 1))
+            ;;
+        esac
+        ;;
+    esac
+  done < <(/usr/bin/find /Users -mindepth 1 -maxdepth 1 -type d \
+              ! -name Shared ! -name Guest ! -name .localized)
+}
+
+# Secure /Users/Shared.
+#
+# This folder is excluded from the user-folder loop above because it is
+# legitimately world-accessible. The CIS / Defender expectation is that it
+# is mode 1777 (drwxrwxrwt) with the sticky bit set, owned by root:wheel.
+SecureSharedFolder() {
+  local sharedDir="/Users/Shared"
+  if [[ ! -d "$sharedDir" ]]; then
+    echo "$(date) | INFO  | $sharedDir does not exist, skipping"
+    return
+  fi
+  local mode owner
+  mode=$(/usr/bin/stat -f "%Lp" "$sharedDir")
+  owner=$(/usr/bin/stat -f "%Su:%Sg" "$sharedDir")
+  if [[ "$mode" == "1777" && "$owner" == "root:wheel" ]]; then
+    echo "$(date) | OK    | $sharedDir already mode 1777 root:wheel"
+    return
+  fi
+  echo "$(date) | FIX   | $sharedDir is mode $mode owner $owner, resetting to 1777 root:wheel"
+  /usr/sbin/chown root:wheel "$sharedDir" || failures=$((failures + 1))
+  /bin/chmod 1777 "$sharedDir"             || failures=$((failures + 1))
+  mode=$(/usr/bin/stat -f "%Lp" "$sharedDir")
+  owner=$(/usr/bin/stat -f "%Su:%Sg" "$sharedDir")
+  if [[ "$mode" == "1777" && "$owner" == "root:wheel" ]]; then
+    echo "$(date) | OK    | $sharedDir is now mode 1777 root:wheel"
+  else
+    echo "$(date) | ERROR | $sharedDir is mode $mode owner $owner after remediation"
+    failures=$((failures + 1))
+  fi
 }
 
 # Start logging
@@ -51,5 +127,14 @@ echo "# $(date) | Starting running of script $appname"
 echo "############################################################"
 echo ""
 
-# Run function
+# Run remediation
 SecureUsersHomeFolders
+SecureSharedFolder
+
+if [[ $failures -gt 0 ]]; then
+  echo "$(date) | $failures item(s) could not be remediated. Exiting 1."
+  exit 1
+fi
+
+echo "$(date) | All user home folders and /Users/Shared are secured. Exiting 0."
+exit 0


### PR DESCRIPTION
Resolves #203.

Thanks @paulh-NC for raising and @DJITS-NL for the [Tech Community link](https://techcommunity.microsoft.com/discussions/microsoft-security/secure-score---secure-home-folders-in-macos/3930746) in the comments — that pointed straight at the cause.

## Why devices stayed non-compliant

The previous script only chmod'd individual user home folders and silently exited `0`. Two problems:

1. **`/Users/Shared` was completely ignored.** Defender / Secure Score expects it to be mode `1777` (sticky bit, world-writable) owned by `root:wheel`. If it drifted from that — for example someone chmod'd it to `777` — the device kept being flagged even though every user folder was perfectly fine.
2. **No verification.** If a `chmod` quietly failed (locked file, immutable flag, SIP-protected path) the script still exited `0`, so Intune saw success while the device was still non-compliant.

## Fix

- New `SecureSharedFolder()` resets `/Users/Shared` to `1777` `root:wheel`.
- `SecureUsersHomeFolders()` rewritten with `-name` filters instead of `grep`, and now stats each folder *after* the chmod and checks the result against the CIS-acceptable set `{700, 711, 750}`.
- Failures are counted and the script exits `1` if anything couldn't be remediated, so Intune surfaces the failure.
- Explicit root check at the top.
- Switched from `/System/Volumes/Data/Users` to `/Users` (firmlinked, same inodes) — `/Users` is the path the Defender posture check evaluates.
- README documents the new behaviour and the `/Users/Shared` requirement.
