### PR TITLE
Fix Microsoft Edge install on Ubuntu 26.04 in Linux Intune Installer

### DIFF
--- a/Linux/Intune Installer/installer.sh
+++ b/Linux/Intune Installer/installer.sh
@@ -18,7 +18,19 @@
 #   --verbose              Show detailed output to the terminal (in addition to the log)
 #   -h, --help             Show this help message
 #
-# Recent changes (Release date: 2026-04-23):
+# Recent changes (Release date: 2026-05-06):
+#   - Fixed Microsoft Edge install on Ubuntu 26.04+: the previous release
+#     overwrote /usr/share/keyrings/microsoft.gpg with the microsoft-2025 key,
+#     which broke GPG verification for the Edge apt repo (signed with the
+#     legacy microsoft.asc key).
+#   - The legacy microsoft.asc key is now always imported to
+#     /usr/share/keyrings/microsoft.gpg so the Edge repo verifies on every
+#     supported Ubuntu release.
+#   - On Ubuntu 26.04+, the microsoft-2025.asc key is additionally imported
+#     to /usr/share/keyrings/microsoft-2025.gpg, and the PMC repo's
+#     signed-by= points to it via the new MS_GPG_KEYRING variable.
+#
+# Previous release (2026-04-23):
 #   - Added repository enrollment checks for APT and YUM/DNF sources
 #   - Updated Microsoft signing key selection for Ubuntu 26.04+ and RHEL/AlmaLinux 10
 #   - Removed stale repo files created by legacy dnf config-manager enrollment
@@ -225,17 +237,21 @@ case "$DISTRO" in
 
     sudo apt-get -y install curl gpg
 
-    # Ubuntu 26.04+ repos are signed with a newer Microsoft GPG key
-    if dpkg --compare-versions "$RELEASE" ge "26.04"; then
-        MS_GPG_KEY_URL="https://packages.microsoft.com/keys/microsoft-2025.asc"
-    else
-        MS_GPG_KEY_URL="https://packages.microsoft.com/keys/microsoft.asc"
-    fi
-
-    # Import Microsoft GPG key (always refresh to pick up key rotations)
-    curl -fsSL "$MS_GPG_KEY_URL" | gpg --dearmor > "$HOME/microsoft.gpg"
+    # Import Microsoft GPG key (always refresh to pick up key rotations).
+    # The Edge repo uses the older microsoft.asc key on all versions.
+    curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > "$HOME/microsoft.gpg"
     sudo install -o root -g root -m 644 "$HOME/microsoft.gpg" /usr/share/keyrings/
     rm -f "$HOME/microsoft.gpg"
+
+    # Ubuntu 26.04+ PMC repos are signed with a newer Microsoft GPG key
+    if dpkg --compare-versions "$RELEASE" ge "26.04"; then
+        MS_GPG_KEYRING="/usr/share/keyrings/microsoft-2025.gpg"
+        curl -fsSL https://packages.microsoft.com/keys/microsoft-2025.asc | gpg --dearmor > "$HOME/microsoft-2025.gpg"
+        sudo install -o root -g root -m 644 "$HOME/microsoft-2025.gpg" /usr/share/keyrings/
+        rm -f "$HOME/microsoft-2025.gpg"
+    else
+        MS_GPG_KEYRING="/usr/share/keyrings/microsoft.gpg"
+    fi
 
     # Clean up any pre-existing Edge repo files to avoid duplicates
     cleanup_edge_repo_duplicates
@@ -250,7 +266,7 @@ case "$DISTRO" in
     if apt_repo_enrolled "packages.microsoft.com/ubuntu/$RELEASE/prod $APT_COMPONENT" "microsoft-$CHANNEL.list"; then
         log "Microsoft $CHANNEL repo already enrolled, skipping."
     else
-        echo "deb [arch=$ARCH signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/ubuntu/$RELEASE/prod $APT_COMPONENT main" \
+        echo "deb [arch=$ARCH signed-by=$MS_GPG_KEYRING] https://packages.microsoft.com/ubuntu/$RELEASE/prod $APT_COMPONENT main" \
             | sudo tee /etc/apt/sources.list.d/microsoft-$CHANNEL.list > /dev/null
     fi
 


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #252 (release 2026-04-23) that breaks Microsoft Edge installation on Ubuntu 26.04+.

## The bug

The previous release wrote the selected Microsoft signing key to a single fixed path:

```
/usr/share/keyrings/microsoft.gpg
```

On Ubuntu 26.04+ this overwrote the legacy `microsoft.asc` key with the newer `microsoft-2025.asc` key. But the Microsoft Edge apt repo (`packages.microsoft.com/repos/edge`) is still signed with the **legacy** key on every Ubuntu release, and our Edge `sources.list.d` entry hard-codes `signed-by=/usr/share/keyrings/microsoft.gpg`. Result: `apt-get update` fails GPG verification on the Edge repo, and `microsoft-edge-stable` cannot install on 26.04.

## The fix

- Always import `microsoft.asc` to `/usr/share/keyrings/microsoft.gpg` so the Edge repo verifies on every supported Ubuntu release.
- On Ubuntu 26.04+, **additionally** import `microsoft-2025.asc` to `/usr/share/keyrings/microsoft-2025.gpg` (separate file, no overwrite).
- New `MS_GPG_KEYRING` variable points the PMC repo's `signed-by=` at the correct keyring per release:
  - Ubuntu 26.04+ \u2192 `/usr/share/keyrings/microsoft-2025.gpg`
  - Ubuntu 22.04 / 24.04 \u2192 `/usr/share/keyrings/microsoft.gpg`
- Edge's `signed-by=` is unchanged (still legacy `microsoft.gpg`), which is now correct on 26.04+ too.
- Header `Recent changes` block updated.

## Scope

- Single file: `Linux/Intune Installer/installer.sh`
- RHEL / AlmaLinux branch is **untouched**.
- No CLI flags, log paths, or repo enrollment behaviour change.

## Testing

- `bash -n` syntax check passes.
- Behaviour validated by re-reading the apt key/repo flow against `packages.microsoft.com` signing key assignments per release.