### PR TITLE
Simplify Company Portal PSSO installer

### DIFF
--- a/macOS/Apps/Company Portal/installCompanyPortalPSSO.zsh
+++ b/macOS/Apps/Company Portal/installCompanyPortalPSSO.zsh
@@ -1,10 +1,11 @@
 #!/bin/zsh
+set -e
 
 ############################################################################################
 ## Install Company Portal for Platform SSO (PSSO) during Setup Assistant
 ## Maintainer: neiljohn@microsoft.com
 ##
-## Summary: Lightweight Company Portal + MAU installer designed to run during macOS Setup
+## Summary: Lightweight Company Portal installer designed to run during macOS Setup
 ##          Assistant for Platform SSO enrollment. Unlike the standard install script, this
 ##          variant skips Rosetta 2 checks, desktop readiness waits, and update checks
 ##          since it runs before the user reaches the desktop and Company Portal will not
@@ -28,67 +29,15 @@
 ## Feedback: neiljohn@microsoft.com
 
 ## Config
-mauurl="https://go.microsoft.com/fwlink/?linkid=830196"
 weburl="https://go.microsoft.com/fwlink/?linkid=853070"
-appname="Company Portal"
-logandmetadir="/Library/Logs/Microsoft/IntuneScripts/installCompanyPortalPSSO"
+logdir="/Library/Logs/Microsoft/IntuneScripts/installCompanyPortalPSSO"
+pkg=$(mktemp -t CompanyPortal).pkg
 
-# Generated variables
-tempdir=$(mktemp -d)
-log="$logandmetadir/$appname.log"
+mkdir -p "$logdir"
+exec > >(tee -a "$logdir/CompanyPortal.log") 2>&1
+trap 'rm -f "$pkg"' EXIT
 
-## Helpers
-cleanup() { [[ -d "$tempdir" ]] && rm -rf "$tempdir"; }
-trap cleanup EXIT
+echo "$(date) | Starting PSSO Setup Assistant install of Company Portal"
 
-startLog() { mkdir -p "$logandmetadir"; exec > >(tee -a "$log") 2>&1; }
-
-downloadPKG() {
-    echo "$(date) | Downloading $appname"
-
-    curl -f -s --connect-timeout 30 --retry 5 --retry-delay 60 -L -o "$tempdir/CompanyPortal.pkg" "$weburl" \
-        || { echo "$(date) | ERROR: Download failed"; exit 1; }
-
-    file -b "$tempdir/CompanyPortal.pkg" | grep -qi xar \
-        || { echo "$(date) | ERROR: Downloaded file is not a valid PKG"; exit 1; }
-
-    echo "$(date) | Download complete"
-}
-
-installMAU() {
-    echo "$(date) | Downloading MAU"
-    curl -f -s --connect-timeout 30 --retry 5 --retry-delay 60 -L -o "$tempdir/mau.pkg" "$mauurl" \
-        || { echo "$(date) | WARNING: MAU download failed, continuing"; return; }
-
-    echo "$(date) | Installing MAU"
-    if installer -pkg "$tempdir/mau.pkg" -target /; then
-        echo "$(date) | MAU installed"
-    else
-        echo "$(date) | WARNING: MAU install failed, continuing"
-    fi
-}
-
-installPKG() {
-    echo "$(date) | Installing $appname"
-
-    if installer -pkg "$tempdir/CompanyPortal.pkg" -target /; then
-        echo "$(date) | Install complete"
-    else
-        echo "$(date) | ERROR: Install failed"; exit 1
-    fi
-}
-
-###################################################################################
-## Begin Script Body
-###################################################################################
-
-startLog
-echo ""
-echo "##############################################################"
-echo "# $(date) | Starting PSSO Setup Assistant install of [$appname]"
-echo "##############################################################"
-echo ""
-
-downloadPKG
-installMAU
-installPKG
+curl -fsSL --connect-timeout 30 --retry 5 --retry-delay 60 -o "$pkg" "$weburl"
+installer -pkg "$pkg" -target /


### PR DESCRIPTION
Simplifies `macOS/Apps/Company Portal/installCompanyPortalPSSO.zsh`:

- Remove MAU download/install — no longer required for the PSSO Setup Assistant flow.
- Inline the helper functions (`downloadPKG`, `installPKG`, `startLog`, `cleanup`) as straight commands.
- Use `set -e` so any failure (curl, installer) surfaces a non-zero exit code automatically, replacing manual `|| exit 1` checks.
- Drop the manual `file ... | grep xar` PKG validation (`installer` already rejects non-PKG input).
- Drop the decorative banner echoes.

Net result: ~50 lines removed, 10 lines of actual logic — log setup, trap, status echo, curl, installer.