### PR TITLE
fix EDGE_GPG_KEY not found error

### DIFF
--- a/Linux/Intune Installer/installer.sh
+++ b/Linux/Intune Installer/installer.sh
@@ -274,7 +274,7 @@ case "$DISTRO" in
     if apt_repo_enrolled "packages.microsoft.com/repos/edge" "microsoft-edge.list"; then
         log "Microsoft Edge repo already enrolled, skipping."
     else
-        echo "deb [arch=$ARCH signed-by=$EDGE_GPG_KEY] https://packages.microsoft.com/repos/edge stable main" \
+        echo "deb [arch=$ARCH signed-by=$MS_GPG_KEYRING] https://packages.microsoft.com/repos/edge stable main" \
             | sudo tee /etc/apt/sources.list.d/microsoft-edge.list > /dev/null
     fi
 


### PR DESCRIPTION
Use MS_GPG_KEYRING in place of EDGE_GPG_KEY var.