### PR TITLE
Pin Microsoft Edge repo to legacy microsoft.gpg key (fix 26.04 signature failure)

### DIFF
--- a/Linux/Intune Installer/installer.sh
+++ b/Linux/Intune Installer/installer.sh
@@ -270,11 +270,15 @@ case "$DISTRO" in
             | sudo tee /etc/apt/sources.list.d/microsoft-$CHANNEL.list > /dev/null
     fi
 
-    # Configure repo for Edge — skip if already enrolled
+    # Configure repo for Edge — skip if already enrolled.
+    # The Edge repo is signed with the legacy microsoft.asc key on every release,
+    # so always pin it to /usr/share/keyrings/microsoft.gpg (NOT MS_GPG_KEYRING,
+    # which points to the microsoft-2025 key on Ubuntu 26.04+ and would fail to
+    # verify the Edge repo signature).
     if apt_repo_enrolled "packages.microsoft.com/repos/edge" "microsoft-edge.list"; then
         log "Microsoft Edge repo already enrolled, skipping."
     else
-        echo "deb [arch=$ARCH signed-by=$MS_GPG_KEYRING] https://packages.microsoft.com/repos/edge stable main" \
+        echo "deb [arch=$ARCH signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/edge stable main" \
             | sudo tee /etc/apt/sources.list.d/microsoft-edge.list > /dev/null
     fi
 


### PR DESCRIPTION
## Summary
Follow-up to #274. That PR fixed the `$EDGE_GPG_KEY` unbound-variable crash by pointing the Microsoft Edge apt repo at `$MS_GPG_KEYRING`. That removes the crash, but on **Ubuntu 26.04+** `$MS_GPG_KEYRING` resolves to `/usr/share/keyrings/microsoft-2025.gpg` — a different signing key than the one that actually signs the Edge repo.

## The problem on Ubuntu 26.04+
- The Edge repo (`packages.microsoft.com/repos/edge`) is signed with the **legacy** `microsoft.asc` key.
- Verified against the live repo: `InRelease` is a **Good signature** from key `EB3E94ADBE1229CF` (legacy `microsoft.gpg`), **not** the microsoft-2025 key `EE4D7792F748182B`.
- On 26.04+ the script sets `MS_GPG_KEYRING=/usr/share/keyrings/microsoft-2025.gpg`, so pinning Edge to `$MS_GPG_KEYRING` makes `apt-get update` fail Edge signature verification, which aborts the installer under `set -e`.
- This is the exact release (26.04) whose testing surfaced the original report.

## Fix
Pin the Edge repo to `/usr/share/keyrings/microsoft.gpg` explicitly on **all** releases. This matches the script's own existing comment that *"The Edge repo uses the older microsoft.asc key on all versions."* The microsoft-2025 key is still used for the PMC/portal repo via `MS_GPG_KEYRING` on 26.04+.

## Testing
- `bash -n installer.sh` → syntax OK.
- Confirmed Edge `InRelease` verifies as a Good signature under the legacy key (`EB3E94ADBE1229CF`).
- Ubuntu ≤24.04 unaffected (there `MS_GPG_KEYRING` already resolves to the legacy keyring); change is a no-op on those releases and corrects 26.04+.
